### PR TITLE
fix: use homejira.app for invite link; add Buy Me a Coffee link

### DIFF
--- a/frontend/src/components/members/HouseholdPanel.tsx
+++ b/frontend/src/components/members/HouseholdPanel.tsx
@@ -213,7 +213,7 @@ export function HouseholdPanel() {
     setSharingLink(true)
     try {
       const { token } = await householdsApi.createInviteLink()
-      const url = `${window.location.origin}/join/${token}`
+      const url = `https://homejira.app/join/${token}`
       const shareTitle = `Join ${household?.name ?? 'our household'} on HomeJira`
       const shareText = `Join ${household?.name ?? 'our household'} on HomeJira 🏠 — the easiest way to manage your household tasks together.`
       if (navigator.share) {
@@ -500,6 +500,22 @@ export function HouseholdPanel() {
           {message}
         </div>
       )}
+
+      <div style={{ textAlign: 'center', paddingBottom: 24, paddingTop: 4 }}>
+        <a
+          href="https://buymeacoffee.com/vibeoski"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            fontSize: 12, color: '#a1a1aa', textDecoration: 'none',
+            padding: '6px 12px', borderRadius: 99, border: '1px solid #e4e4e7',
+            background: 'white', transition: 'all 0.15s',
+          }}
+        >
+          ☕ Buy me a coffee
+        </a>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Invite links now hardcode `https://homejira.app` instead of `window.location.origin` so they always point to the production domain regardless of which environment generates them
- Adds a subtle ☕ Buy Me a Coffee link at the bottom of the household panel

## Test plan
- [ ] Share invite link — URL should be `https://homejira.app/join/<token>`
- [ ] Buy Me a Coffee link opens `https://buymeacoffee.com/vibeoski` in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)