### PR TITLE
feat: Sprint 1 UI/UX critical fixes + nullable assignee

### DIFF
--- a/backend/internal/db/migrations/000014_nullable_assignee.down.sql
+++ b/backend/internal/db/migrations/000014_nullable_assignee.down.sql
@@ -1,0 +1,12 @@
+-- Revert: restore NOT NULL and CASCADE delete on assignee_id.
+-- NOTE: this will fail if any tasks have assignee_id = NULL.
+
+ALTER TABLE tasks
+    DROP CONSTRAINT IF EXISTS fk_tasks_assignee;
+
+ALTER TABLE tasks
+    ADD CONSTRAINT tasks_assignee_id_fkey
+        FOREIGN KEY (assignee_id) REFERENCES members(id) ON DELETE CASCADE;
+
+ALTER TABLE tasks
+    ALTER COLUMN assignee_id SET NOT NULL;

--- a/backend/internal/db/migrations/000014_nullable_assignee.up.sql
+++ b/backend/internal/db/migrations/000014_nullable_assignee.up.sql
@@ -1,0 +1,13 @@
+-- Allow tasks to be unassigned (assignee_id nullable).
+-- Drops the NOT NULL constraint and changes ON DELETE CASCADE to SET NULL
+-- so deleting a member doesn't cascade-delete their tasks.
+
+ALTER TABLE tasks
+    ALTER COLUMN assignee_id DROP NOT NULL;
+
+ALTER TABLE tasks
+    DROP CONSTRAINT IF EXISTS tasks_assignee_id_fkey;
+
+ALTER TABLE tasks
+    ADD CONSTRAINT fk_tasks_assignee
+        FOREIGN KEY (assignee_id) REFERENCES members(id) ON DELETE SET NULL;

--- a/backend/internal/domain/task.go
+++ b/backend/internal/domain/task.go
@@ -32,7 +32,7 @@ type Task struct {
 	Notes       string     `json:"notes"`
 	Category    Category   `json:"category"`
 	Priority    Priority   `json:"priority"`
-	AssigneeID  uuid.UUID  `json:"assignee_id"`
+	AssigneeID  *uuid.UUID `json:"assignee_id"`
 	HouseholdID uuid.UUID  `json:"household_id"`
 	Done        bool       `json:"done"`
 	DoneAt      *time.Time `json:"done_at,omitempty"`
@@ -41,7 +41,7 @@ type Task struct {
 	UpdatedAt   time.Time  `json:"updated_at"`
 
 	// Populated from joins
-	Assignee *Member   `json:"assignee,omitempty"`
+	Assignee *Member   `json:"assignee"`
 	Comments []Comment `json:"comments,omitempty"`
 }
 
@@ -62,7 +62,7 @@ type CreateTaskInput struct {
 	Notes       string     `json:"notes"`
 	Category    Category   `json:"category"`
 	Priority    Priority   `json:"priority"`
-	AssigneeID  uuid.UUID  `json:"assignee_id"`
+	AssigneeID  *uuid.UUID `json:"assignee_id"`
 	HouseholdID uuid.UUID  `json:"household_id"`
 	DueAt       *time.Time `json:"due_at,omitempty"`
 	ActorID     uuid.UUID  `json:"-"` // who triggered the action (not from client body)

--- a/backend/internal/repository/task_repo.go
+++ b/backend/internal/repository/task_repo.go
@@ -14,6 +14,29 @@ import (
 	"github.com/homejira/api/internal/domain"
 )
 
+// nullUUID is a helper for scanning a potentially-NULL UUID column.
+type nullUUID struct {
+	UUID  uuid.UUID
+	Valid bool
+}
+
+func (n *nullUUID) Scan(v any) error {
+	if v == nil {
+		n.Valid = false
+		return nil
+	}
+	n.Valid = true
+	if u, ok := v.(uuid.UUID); ok {
+		n.UUID = u
+		return nil
+	}
+	if b, ok := v.([16]byte); ok {
+		n.UUID = uuid.UUID(b)
+		return nil
+	}
+	return fmt.Errorf("nullUUID: cannot scan type %T", v)
+}
+
 type taskRepo struct {
 	db *pgxpool.Pool
 }
@@ -26,16 +49,18 @@ func NewTaskRepository(db *pgxpool.Pool) domain.TaskRepository {
 const taskSelectCols = `
 	t.id, t.title, t.notes, t.category, t.priority,
 	t.assignee_id, t.household_id, t.done, t.done_at, t.due_at, t.created_at, t.updated_at,
-	m.id, m.name, m.avatar, m.color, m.created_at
+	m.id, COALESCE(m.name, ''), COALESCE(m.avatar, ''), COALESCE(m.color, ''), m.created_at
 `
 
 func scanTaskWithMember(row pgx.Row) (*domain.Task, error) {
 	var t domain.Task
-	var m domain.Member
+	var mID nullUUID
+	var mName, mAvatar, mColor string
+	var mCreatedAt *time.Time
 	err := row.Scan(
 		&t.ID, &t.Title, &t.Notes, &t.Category, &t.Priority,
 		&t.AssigneeID, &t.HouseholdID, &t.Done, &t.DoneAt, &t.DueAt, &t.CreatedAt, &t.UpdatedAt,
-		&m.ID, &m.Name, &m.Avatar, &m.Color, &m.CreatedAt,
+		&mID, &mName, &mAvatar, &mColor, &mCreatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, domain.ErrNotFound
@@ -43,7 +68,18 @@ func scanTaskWithMember(row pgx.Row) (*domain.Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	t.Assignee = &m
+	if mID.Valid {
+		m := domain.Member{
+			ID:     mID.UUID,
+			Name:   mName,
+			Avatar: mAvatar,
+			Color:  mColor,
+		}
+		if mCreatedAt != nil {
+			m.CreatedAt = *mCreatedAt
+		}
+		t.Assignee = &m
+	}
 	return &t, nil
 }
 
@@ -76,7 +112,7 @@ func (r *taskRepo) FindAll(filter domain.TaskFilter) ([]domain.Task, error) {
 	q := fmt.Sprintf(`
 		SELECT %s
 		FROM tasks t
-		JOIN members m ON m.id = t.assignee_id
+		LEFT JOIN members m ON m.id = t.assignee_id
 		WHERE %s
 		ORDER BY
 			CASE t.priority WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 ELSE 2 END,
@@ -93,15 +129,28 @@ func (r *taskRepo) FindAll(filter domain.TaskFilter) ([]domain.Task, error) {
 	var tasks []domain.Task
 	for rows.Next() {
 		var t domain.Task
-		var m domain.Member
+		var mID nullUUID
+		var mName, mAvatar, mColor string
+		var mCreatedAt *time.Time
 		if err := rows.Scan(
 			&t.ID, &t.Title, &t.Notes, &t.Category, &t.Priority,
 			&t.AssigneeID, &t.HouseholdID, &t.Done, &t.DoneAt, &t.DueAt, &t.CreatedAt, &t.UpdatedAt,
-			&m.ID, &m.Name, &m.Avatar, &m.Color, &m.CreatedAt,
+			&mID, &mName, &mAvatar, &mColor, &mCreatedAt,
 		); err != nil {
 			return nil, err
 		}
-		t.Assignee = &m
+		if mID.Valid {
+			m := domain.Member{
+				ID:     mID.UUID,
+				Name:   mName,
+				Avatar: mAvatar,
+				Color:  mColor,
+			}
+			if mCreatedAt != nil {
+				m.CreatedAt = *mCreatedAt
+			}
+			t.Assignee = &m
+		}
 		tasks = append(tasks, t)
 	}
 
@@ -119,7 +168,7 @@ func (r *taskRepo) FindByID(id uuid.UUID) (*domain.Task, error) {
 	row := r.db.QueryRow(context.Background(), fmt.Sprintf(`
 		SELECT %s
 		FROM tasks t
-		JOIN members m ON m.id = t.assignee_id
+		LEFT JOIN members m ON m.id = t.assignee_id
 		WHERE t.id = $1
 	`, taskSelectCols), id)
 
@@ -144,7 +193,7 @@ func (r *taskRepo) Create(input domain.CreateTaskInput) (*domain.Task, error) {
 			RETURNING *
 		)
 		SELECT %s FROM ins t
-		JOIN members m ON m.id = t.assignee_id
+		LEFT JOIN members m ON m.id = t.assignee_id
 	`, taskSelectCols),
 		input.Title, input.Notes, input.Category, input.Priority, input.AssigneeID, input.HouseholdID, input.DueAt,
 	)
@@ -220,7 +269,7 @@ func (r *taskRepo) Update(id uuid.UUID, input domain.UpdateTaskInput) (*domain.T
 			UPDATE tasks SET %s WHERE id = $%d RETURNING *
 		)
 		SELECT %s FROM upd t
-		JOIN members m ON m.id = t.assignee_id
+		LEFT JOIN members m ON m.id = t.assignee_id
 	`, strings.Join(setClauses, ", "), i, taskSelectCols), args...)
 
 	return scanTaskWithMember(row)

--- a/backend/internal/service/task_service.go
+++ b/backend/internal/service/task_service.go
@@ -109,7 +109,8 @@ func (s *TaskService) recordUpdateActivities(old, new *domain.Task, input domain
 		s.activities.Create(new.ID, actorID, kind, nil) //nolint:errcheck
 	}
 
-	if input.AssigneeID != nil && *input.AssigneeID != old.AssigneeID {
+	assigneeChanged := input.AssigneeID != nil && (old.AssigneeID == nil || *input.AssigneeID != *old.AssigneeID)
+	if assigneeChanged {
 		fromName := ""
 		toName := ""
 		if old.Assignee != nil {
@@ -160,7 +161,7 @@ func (s *TaskService) recordUpdateActivities(old, new *domain.Task, input domain
 	}
 }
 
-func (s *TaskService) validateTaskInput(title string, category domain.Category, priority domain.Priority, assigneeID uuid.UUID) error {
+func (s *TaskService) validateTaskInput(title string, category domain.Category, priority domain.Priority, assigneeID *uuid.UUID) error {
 	if title == "" {
 		return fmt.Errorf("%w: title required", domain.ErrInvalidInput)
 	}
@@ -170,8 +171,10 @@ func (s *TaskService) validateTaskInput(title string, category domain.Category, 
 	if !validPriority(priority) {
 		return fmt.Errorf("%w: invalid priority", domain.ErrInvalidInput)
 	}
-	if _, err := s.members.FindByID(assigneeID); err != nil {
-		return fmt.Errorf("%w: assignee not found", domain.ErrInvalidInput)
+	if assigneeID != nil {
+		if _, err := s.members.FindByID(*assigneeID); err != nil {
+			return fmt.Errorf("%w: assignee not found", domain.ErrInvalidInput)
+		}
 	}
 	return nil
 }

--- a/backend/internal/service/task_service_test.go
+++ b/backend/internal/service/task_service_test.go
@@ -26,7 +26,7 @@ func seedMemberAndTask(t *testing.T) (*mockMemberRepo, *mockTaskRepo, *domain.Me
 		Title:       "Buy milk",
 		Category:    domain.CategoryGrocery,
 		Priority:    domain.PriorityNormal,
-		AssigneeID:  m.ID,
+		AssigneeID:  &m.ID,
 		HouseholdID: uuid.New(),
 		ActorID:     m.ID,
 	})
@@ -49,7 +49,7 @@ func TestTaskService_CreateTask_Success(t *testing.T) {
 		Title:       "Fix fence",
 		Category:    domain.CategoryRepair,
 		Priority:    domain.PriorityHigh,
-		AssigneeID:  m.ID,
+		AssigneeID:  &m.ID,
 		HouseholdID: uuid.New(),
 		ActorID:     m.ID,
 	})
@@ -71,7 +71,7 @@ func TestTaskService_CreateTask_EmptyTitle(t *testing.T) {
 		Title:      "",
 		Category:   domain.CategoryChore,
 		Priority:   domain.PriorityNormal,
-		AssigneeID: m.ID,
+		AssigneeID: &m.ID,
 		ActorID:    m.ID,
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
@@ -89,7 +89,7 @@ func TestTaskService_CreateTask_InvalidCategory(t *testing.T) {
 		Title:      "Something",
 		Category:   "invalid",
 		Priority:   domain.PriorityNormal,
-		AssigneeID: m.ID,
+		AssigneeID: &m.ID,
 		ActorID:    m.ID,
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
@@ -107,7 +107,7 @@ func TestTaskService_CreateTask_InvalidPriority(t *testing.T) {
 		Title:      "Something",
 		Category:   domain.CategoryChore,
 		Priority:   "critical",
-		AssigneeID: m.ID,
+		AssigneeID: &m.ID,
 		ActorID:    m.ID,
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
@@ -118,11 +118,12 @@ func TestTaskService_CreateTask_InvalidPriority(t *testing.T) {
 func TestTaskService_CreateTask_AssigneeNotFound(t *testing.T) {
 	svc := newTaskSvc(newMockTaskRepo(), newMockMemberRepo())
 
+	unknownID := uuid.New()
 	_, err := svc.CreateTask(domain.CreateTaskInput{
 		Title:      "Something",
 		Category:   domain.CategoryChore,
 		Priority:   domain.PriorityNormal,
-		AssigneeID: uuid.New(), // not seeded
+		AssigneeID: &unknownID, // not seeded
 		ActorID:    uuid.New(),
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,0 +1,480 @@
+# HomeJira — Product Documentation
+
+> **Version:** 0.1.0 · **Last updated:** March 2026
+
+---
+
+## Table of Contents
+
+1. [What is HomeJira?](#1-what-is-homejira)
+2. [Who is it for?](#2-who-is-it-for)
+3. [Core Concepts](#3-core-concepts)
+4. [Authentication](#4-authentication)
+5. [Households](#5-households)
+6. [Tasks](#6-tasks)
+7. [Grocery List](#7-grocery-list)
+8. [Comments & Activity Feed](#8-comments--activity-feed)
+9. [Member Profiles](#9-member-profiles)
+10. [Real-Time Sync](#10-real-time-sync)
+11. [Stats Dashboard](#11-stats-dashboard)
+12. [Coins & Referrals](#12-coins--referrals)
+13. [Feature Flags](#13-feature-flags)
+14. [Guest Mode](#14-guest-mode)
+15. [API Reference](#15-api-reference)
+
+---
+
+## 1. What is HomeJira?
+
+HomeJira is a **household task management app** — think Jira, but for the people you live with.
+
+It gives households a shared space to create, assign, track, and complete household tasks. Instead of sticky notes on the fridge, lost WhatsApp messages, or awkward "did you do the thing?" conversations, HomeJira puts everything in one place with clear ownership, priorities, and history.
+
+The name comes from the team's belief that running a home deserves the same structured tooling that engineering teams use. Chores get priorities. Errands get assignees. Groceries get a list. Nothing falls through the cracks.
+
+---
+
+## 2. Who is it for?
+
+HomeJira is built for any group of people sharing a living space and responsibilities:
+
+- **Families** coordinating chores, errands, and shopping across family members
+- **Flatmates** managing shared household duties fairly
+- **Couples** splitting tasks without friction
+- **Any household** that has ever asked "who was supposed to buy milk?"
+
+The app is mobile-first, lightweight, and designed to be picked up with no onboarding — just register with a phone number, create or join a household, and start adding tasks.
+
+---
+
+## 3. Core Concepts
+
+### Members
+A **member** is a user account. Every member has a name, a profile color, an emoji avatar, and a phone number. Members authenticate with a 4-digit mPIN (similar to a phone PIN). There are no passwords or email addresses required to use the app.
+
+### Households
+A **household** is the central container. Tasks, members, and activities all belong to a household. A member can only belong to one household at a time. The person who creates the household becomes the **admin**.
+
+### Tasks
+A **task** is the fundamental unit of work. Each task has a title, category (chore, errand, repair, grocery), priority (urgent, high, normal), and an optional assignee, notes, and due date. Tasks can be toggled between open and done.
+
+### Roles
+There are two roles inside a household:
+- **Admin** — full control: invite members, approve join requests, remove members, promote other admins, delete the household.
+- **Member** — regular participant: create and manage tasks, view the household.
+
+---
+
+## 4. Authentication
+
+HomeJira uses **phone + 4-digit mPIN** authentication — no email, no password, no app store account required.
+
+### Registration
+1. Enter your phone number.
+2. If the number is not registered, you're taken to the **Create Profile** screen.
+3. Enter your name, choose an emoji avatar, set a 4-digit mPIN, and confirm it.
+4. Tap **Create account** — you're immediately logged in.
+
+### Login
+1. Enter your phone number.
+2. Enter your 4-digit mPIN.
+3. You're in.
+
+### Security
+- mPINs are **bcrypt-hashed** before storage. The raw PIN is never saved or logged.
+- Authentication returns a **JWT** (JSON Web Token) with a 7-day TTL. The token includes your member ID, name, avatar, color, and household ID.
+- All protected API calls require a valid `Authorization: Bearer <token>` header.
+- The server validates the token on every request and confirms the member exists in the database.
+
+### Changing Your mPIN
+From the account menu → **Change PIN**, enter your current PIN and new PIN (twice to confirm).
+
+---
+
+## 5. Households
+
+A household is the shared space where all tasks and members live. You need to either create a household or join one before you can create tasks.
+
+### Creating a Household
+From the **Household** tab, tap **Create household**. Give it a name and choose a type:
+- **Home** — for a family or couple sharing a home
+- **Group** — for flatmates or any other group arrangement
+
+You become the admin immediately. A unique **join code** is generated automatically.
+
+### Joining a Household
+
+There are three ways to join a household:
+
+#### 1. Join via Code
+Ask your household admin for the join code. Enter it in the app under **Join household**. This creates a **join request** that the admin must approve.
+
+While your request is pending, the app shows a waiting screen. You'll be notified via real-time sync the moment the admin approves.
+
+#### 2. Join via Shareable Link
+Admins can generate a **shareable invite link** (valid for 7 days) from the Household settings. Anyone who opens the link is taken to a join page and can join directly — no approval needed. This is the fastest way to onboard someone new.
+
+#### 3. Invite by Phone (admin-initiated)
+Admins can invite a phone number directly. The invited person sees a pending invite when they open the app, and can accept or reject it.
+
+### Leaving a Household
+Any member can leave from Household settings → **Leave household**. Your open tasks are automatically reassigned to another member (preferably an admin).
+
+**Note:** If you're the only admin, you must promote another member to admin before you can leave.
+
+### Household Administration (Admin only)
+- **Approve / Reject join requests** — manage the queue of people who want in
+- **Remove a member** — kicks a member from the household; their open tasks are reassigned
+- **Promote a member to admin** — give full admin rights to another member
+- **Delete the household** — permanently deletes the household, all its tasks, and removes everyone's membership. This cannot be undone.
+
+---
+
+## 6. Tasks
+
+Tasks are the core of HomeJira. Every task belongs to a household and optionally to a member (assignee).
+
+### Task Fields
+
+| Field | Description |
+|-------|-------------|
+| **Title** | What needs to be done |
+| **Notes** | Optional longer description or instructions |
+| **Category** | `chore`, `errand`, `repair`, or `grocery` |
+| **Priority** | `urgent`, `high`, or `normal` |
+| **Assignee** | Which member is responsible (optional) |
+| **Due date** | When it should be done by (optional) |
+| **Done** | Completed or not |
+
+### Creating a Task
+Tap the **+** button on the Tasks page. Fill in a title (required), choose a category and priority, optionally assign to a member and set a due date. Tap **Add task**.
+
+### Task Categories
+
+| Category | Emoji | Description |
+|----------|-------|-------------|
+| Grocery | 🛒 | Items to buy — shown separately in the Grocery List |
+| Chore | 🧹 | Regular household maintenance |
+| Errand | 📦 | Things to do outside the home |
+| Repair | 🔧 | Broken things that need fixing |
+
+### Task Priorities
+
+| Priority | Color | Description |
+|----------|-------|-------------|
+| Urgent | 🔴 Red | Needs immediate attention |
+| High | 🟠 Orange | Important but not on fire |
+| Normal | ⚫ Grey | Standard task |
+
+### Filtering and Sorting
+The Tasks page (non-grocery tasks) supports:
+- **Category tabs** — filter by chore, errand, repair, or see all
+- **Status filter** — open tasks, done tasks, or all
+- **My tasks toggle** — show only tasks assigned to you
+- **Priority sort** — urgent first, then high, then normal
+- **Recent sort** — last updated first
+- **Search** — filter by task title text
+
+### Completing a Task
+Tap the checkbox on a task card to mark it done. Tap again to reopen it. The completion is recorded with a timestamp. Activity is logged.
+
+### Editing a Task
+Tap any task to open the detail drawer. From there you can:
+- Edit the title and notes inline
+- Change category, priority, assignee
+- Set or clear the due date
+- Add a comment
+- Delete the task
+
+### Deleting a Task
+From the task drawer, tap the delete icon (trash). There's a confirmation step. Deleted tasks are permanently removed.
+
+---
+
+## 7. Grocery List
+
+The Grocery List is a dedicated view for all tasks with the `grocery` category. It's designed to feel like a shopping list rather than a task board.
+
+### Features
+- **Quick add** — type an item at the top and tap Add (or press Enter)
+- **Check off items** — tap any item to mark it as bought
+- **Check all** — bulk-complete all active items in one tap
+- **Inline edit** — tap an item's text to edit it in place
+- **Done section** — completed items collapse into a foldable "Done" section
+- **Assignee display** — each item shows the avatar of who added it
+- **Delete** — swipe or tap the × on any item to remove it
+
+### History View
+Switch to **History** mode to see all completed grocery items grouped by date:
+- Today
+- Yesterday
+- Specific dates further back
+
+This makes it easy to recall what you bought last week or recreate a regular shopping list.
+
+### Navigation
+The Grocery List is its own tab in the bottom navigation, completely separate from the main task board. Grocery tasks do **not** appear on the Tasks page.
+
+---
+
+## 8. Comments & Activity Feed
+
+Every task has a unified feed combining **comments** (written by members) and **activity events** (automatically generated by the system).
+
+### Comments
+Any member can add a comment to a task from the task drawer. Comments show:
+- The author's avatar and name
+- The comment text
+- How long ago it was posted (relative time, e.g. "3 hours ago")
+
+### Activity Events
+The system automatically records an activity event every time a significant change happens to a task:
+
+| Event | What triggered it |
+|-------|-------------------|
+| **Created** | Task was created |
+| **Completed** | Task was marked done |
+| **Reopened** | Task was un-checked |
+| **Assigned** | Assignee changed (logs from → to) |
+| **Priority changed** | Priority updated (logs from → to) |
+| **Category changed** | Category updated (logs from → to) |
+| **Title changed** | Title was edited |
+| **Notes changed** | Notes were edited |
+| **Due date set** | Due date was added or changed |
+| **Due date cleared** | Due date was removed |
+
+Activities are combined with comments into a single chronological feed in the task drawer, making it easy to see the full history of a task at a glance.
+
+---
+
+## 9. Member Profiles
+
+### Profile Information
+Each member has:
+- **Name** — displayed throughout the app
+- **Emoji avatar** — chosen from 18 options (people and animals)
+- **Color** — chosen from 8 colors; used for avatar background, task indicators, and UI accents
+- **Phone number** — used for authentication; shown in your own profile view
+
+### Letter Avatars
+Avatars are displayed as a colored circle with the **first letter of the member's name** — Google-style. The background color is the member's chosen profile color. This makes members immediately recognisable at a glance across task cards, comments, and member lists.
+
+### Editing Your Profile
+From the account menu (top-right), tap **Edit profile**:
+- Change your name
+- Pick a different emoji (shown in the avatar circle overlay)
+- Choose a different color
+
+Changes take effect immediately.
+
+### Color Assignment
+On registration, a color is automatically assigned from the 8-color palette by cycling through it based on how many members have registered. You can change it at any time.
+
+### Member List
+The household member list is visible on the Tasks page (first 4 members shown, "+N" for more) and in full on the Members/Household page.
+
+---
+
+## 10. Real-Time Sync
+
+HomeJira uses **Server-Sent Events (SSE)** to push live updates to all household members. You don't need to refresh the app to see changes made by other members.
+
+### How it Works
+When you're in the app, your browser maintains a persistent connection to the server. When any household member makes a change (creates a task, completes one, joins the household, etc.), the server sends a notification through that connection. Your app then silently refetches the relevant data in the background.
+
+### What Triggers a Sync
+- Any task created, updated, or deleted
+- A comment added to a task
+- A member approved to join the household
+- A member removed from the household
+- Any household setting changed
+
+### Implementation
+The SSE connection authenticates via a `?token=` query parameter (since `EventSource` cannot set custom headers). The stream endpoint is `GET /api/v1/events?token=<jwt>`. The connection is kept open indefinitely — server write timeouts are disabled for this endpoint.
+
+---
+
+## 11. Stats Dashboard
+
+The Stats page provides a visual summary of your household's task activity.
+
+Accessible via the **Stats** tab in the bottom navigation.
+
+Data is sourced from the current household's tasks and members in the Zustand store — no extra API call is needed.
+
+*Detailed breakdown of stats charts and metrics is rendered in `StatsScreen` component.*
+
+---
+
+## 12. Coins & Referrals
+
+HomeJira has a lightweight **coin economy** designed to reward members for growing the community.
+
+> ⚠️ The coins feature is currently **disabled** by default via the feature flag system. The full implementation is in place and can be enabled.
+
+### Earning Coins
+
+| Action | Coins Earned |
+|--------|-------------|
+| Someone joins your household via your shareable invite link | **+20 coins** |
+| A new user registers using your referral link | **+10 coins** |
+
+### Referral Links
+Each member can generate a unique referral link from their account menu under **Coins**. The link goes to a public page showing the referrer's profile (name, avatar, color) with a call-to-action to sign up.
+
+When a new user registers via your referral link:
+1. The referral token is stored in their browser during onboarding
+2. On registration, the token is validated and 10 coins are credited to you
+3. You can't refer yourself — self-referral is blocked
+
+### Coin Balance
+Your current balance and full transaction history are visible in the account menu → **Coins** sheet. Each transaction shows the reason, who triggered it, and the timestamp.
+
+### Transaction Reasons
+- `household_invite` — 20 coins when someone joins via your shareable link
+- `referral` — 10 coins when a new member registers with your referral token
+
+---
+
+## 13. Feature Flags
+
+HomeJira uses a **database-driven feature flag system** to toggle features on and off without a code deployment.
+
+### How It Works
+Flags are stored in the `feature_flags` database table and served to the frontend via the public `GET /api/v1/config` endpoint. The frontend fetches this at startup and makes flag state available across all components.
+
+### Current Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `grocery_list` | ✅ Enabled | Grocery list tab and functionality |
+| `stats` | ✅ Enabled | Stats dashboard tab |
+| `coins` | ❌ Disabled | Coin earning and balance display |
+| `referral_system` | ❌ Disabled | Referral link generation and processing |
+| `phone_verification` | ❌ Disabled | Reserved (feature removed) |
+| `email_verification` | ❌ Disabled | Reserved (feature removed) |
+
+### Enabling a Flag
+Connect to the database and run:
+```sql
+UPDATE feature_flags SET enabled = true WHERE key = 'coins';
+```
+The change takes effect on the next app load — no server restart needed.
+
+---
+
+## 14. Guest Mode
+
+Users who don't want to create an account can use HomeJira in **Guest Mode** by tapping "Skip" on the auth screen.
+
+### What Guest Mode Offers
+- Full task creation and management
+- All categories and priorities
+- Grocery list
+
+### How It Works
+In guest mode, all data is stored locally in the browser's `localStorage`. No API calls are made for task mutations. A static guest member profile is used as the task assignee.
+
+### Limitations
+- Data exists only on the current device and browser
+- No household collaboration — guest tasks are private
+- No real-time sync with other members
+- No coins, referrals, or activity history
+- Data is lost if the browser cache is cleared
+
+A **Guest Banner** is shown throughout the app, encouraging the user to create a free account to unlock all features and sync across devices.
+
+---
+
+## 15. API Reference
+
+All endpoints are prefixed with `/api/v1`.
+
+### Authentication
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/auth/check-phone` | — | Check if a phone number is registered |
+| `POST` | `/auth/login` | — | Login with phone + mPIN |
+| `POST` | `/auth/register` | — | Register new member |
+| `POST` | `/auth/refresh` | ✅ | Reissue JWT with latest DB state |
+| `PATCH` | `/auth/mpin` | ✅ | Change mPIN |
+
+### Config
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/config` | — | Get app feature flags |
+
+### Members
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/members` | ✅ | List all members in household |
+| `POST` | `/members` | ✅ | Create a member |
+| `PATCH` | `/members/me` | ✅ | Update own profile (name, avatar, color) |
+| `GET` | `/members/{id}` | ✅ | Get member by ID |
+| `GET` | `/members/me/coins` | ✅ | Get coin balance + transaction history |
+| `GET` | `/members/me/referral-link` | ✅ | Get or create referral token |
+
+### Tasks
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/tasks` | ✅ | List tasks (filterable) |
+| `POST` | `/tasks` | ✅ | Create task |
+| `GET` | `/tasks/{id}` | ✅ | Get task with comments |
+| `PATCH` | `/tasks/{id}` | ✅ | Update task (partial) |
+| `DELETE` | `/tasks/{id}` | ✅ | Delete task |
+| `POST` | `/tasks/{id}/comments` | ✅ | Add comment |
+| `GET` | `/tasks/{id}/activity` | ✅ | Get activity history |
+
+### Households
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/households/me` | ✅ | Get own household |
+| `POST` | `/households` | ✅ | Create household |
+| `POST` | `/households/join-by-code` | ✅ | Request to join via join code |
+| `POST` | `/households/leave` | ✅ | Leave household |
+| `DELETE` | `/households` | ✅ Admin | Delete household |
+| `POST` | `/households/invite-link` | ✅ Admin | Generate shareable invite link |
+| `GET` | `/households/link/{token}` | — | Resolve invite link (public) |
+| `POST` | `/households/link/{token}/join` | ✅ | Join via invite link |
+| `POST` | `/households/members/{id}/remove` | ✅ Admin | Remove a member |
+| `POST` | `/households/members/{id}/promote` | ✅ Admin | Promote to admin |
+
+### Join Requests
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/households/requests/mine` | ✅ | Get own pending join request |
+| `GET` | `/households/requests` | ✅ Admin | List pending requests |
+| `POST` | `/households/requests/{id}/approve` | ✅ Admin | Approve request |
+| `POST` | `/households/requests/{id}/reject` | ✅ Admin | Reject request |
+| `POST` | `/households/requests/{id}/cancel` | ✅ | Cancel own request |
+
+### Household Invites
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/households/invites` | ✅ Admin | Invite a phone number |
+| `GET` | `/households/invites/me` | ✅ | Get pending invites for own phone |
+| `POST` | `/households/invites/{id}/accept` | ✅ | Accept invite |
+| `POST` | `/households/invites/{id}/reject` | ✅ | Reject invite |
+
+### Real-Time
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/events?token=<jwt>` | token param | SSE live update stream |
+
+### Referral
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/referral/{token}` | — | Get referrer public profile |
+
+---
+
+*For technical architecture and development setup, see [README.md](../README.md) and [CLAUDE.md](../CLAUDE.md).*

--- a/frontend/src/components/auth/MPINStep.tsx
+++ b/frontend/src/components/auth/MPINStep.tsx
@@ -2,6 +2,8 @@ import { useRef, useState } from 'react'
 import { authApi } from '../../api/auth'
 import type { Member } from '../../types'
 
+const spinKeyframes = `@keyframes mpin-spin { to { transform: rotate(360deg); } }`
+
 interface Props {
   phone: string
   onSuccess: (token: string, member: Member) => void
@@ -14,12 +16,11 @@ export function MPINStep({ phone, onSuccess, onBack }: Props) {
   const [digits, setDigits] = useState(['', '', '', ''])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const refs = [
-    useRef<HTMLInputElement>(null),
-    useRef<HTMLInputElement>(null),
-    useRef<HTMLInputElement>(null),
-    useRef<HTMLInputElement>(null),
-  ]
+  const ref0 = useRef<HTMLInputElement>(null)
+  const ref1 = useRef<HTMLInputElement>(null)
+  const ref2 = useRef<HTMLInputElement>(null)
+  const ref3 = useRef<HTMLInputElement>(null)
+  const refs = [ref0, ref1, ref2, ref3]
 
   const handleDigit = (idx: number, val: string) => {
     if (!/^\d?$/.test(val)) return
@@ -74,14 +75,17 @@ export function MPINStep({ phone, onSuccess, onBack }: Props) {
             value={d}
             maxLength={1}
             autoFocus={i === 0}
+            disabled={loading}
             onChange={(e) => handleDigit(i, e.target.value)}
             onKeyDown={(e) => handleKeyDown(i, e)}
             style={{
               width: 54, height: 60, textAlign: 'center', fontSize: 24,
               borderRadius: 10, border: `1.5px solid ${d ? ACCENT : '#e4e4e7'}`,
               fontWeight: 700, outline: 'none',
-              background: d ? '#eef2ff' : '#f9f9f9',
+              background: loading ? '#f4f4f5' : d ? '#eef2ff' : '#f9f9f9',
               color: '#18181b',
+              opacity: loading ? 0.6 : 1,
+              cursor: loading ? 'not-allowed' : 'text',
               transition: 'border-color 0.12s, background 0.12s',
             }}
           />
@@ -89,7 +93,17 @@ export function MPINStep({ phone, onSuccess, onBack }: Props) {
       </div>
 
       {error && <p style={{ color: '#ef4444', fontSize: 12, textAlign: 'center', marginBottom: 10 }}>{error}</p>}
-      {loading && <p style={{ color: '#a1a1aa', fontSize: 12, textAlign: 'center' }}>Verifying…</p>}
+      {loading && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, marginTop: 4 }}>
+          <style>{spinKeyframes}</style>
+          <div style={{
+            width: 16, height: 16, borderRadius: '50%',
+            border: '2px solid #e4e4e7', borderTopColor: ACCENT,
+            animation: 'mpin-spin 0.7s linear infinite', flexShrink: 0,
+          }} />
+          <span style={{ color: '#a1a1aa', fontSize: 12 }}>Verifying…</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -100,7 +100,14 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
 
       {/* Right: Avatar + priority dot */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6, flexShrink: 0 }}>
-        {task.assignee && <Avatar member={task.assignee} size={26} />}
+        {task.assignee ? (
+          <Avatar member={task.assignee} size={26} />
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+            <div style={{ width: 26, height: 26, borderRadius: '50%', backgroundColor: '#d4cfc8', flexShrink: 0 }} />
+            <span style={{ color: '#a8a29e', fontSize: 11, whiteSpace: 'nowrap' }}>Unassigned</span>
+          </div>
+        )}
         <span style={{
           width: 7, height: 7, borderRadius: '50%', display: 'block',
           background: PRIORITIES[task.priority].color,

--- a/frontend/src/components/tasks/TaskDrawer.tsx
+++ b/frontend/src/components/tasks/TaskDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Avatar } from '../ui/Avatar'
 import { CATEGORIES, PRIORITIES, type Task, type Member, type UpdateTaskPayload, type Category, type Priority, type Activity } from '../../types'
 import { tasksApi } from '../../api/tasks'
@@ -62,6 +62,35 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
     }
   }
 
+  // Swipe-to-close gesture state
+  const [isDragging, setIsDragging] = useState(false)
+  const [dragY, setDragY] = useState(0)
+  const startYRef = useRef(0)
+  const sheetRef = useRef<HTMLDivElement>(null)
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    startYRef.current = e.touches[0].clientY
+    setIsDragging(true)
+    setDragY(0)
+  }
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const delta = e.touches[0].clientY - startYRef.current
+    if (delta > 0) {
+      setDragY(delta)
+    }
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    setIsDragging(false)
+    const endY = e.changedTouches[0].clientY
+    if (endY - startYRef.current > 80) {
+      onClose()
+    } else {
+      setDragY(0)
+    }
+  }
+
   // Merge comments + activities into a single chronological feed
   type FeedItem = { type: 'comment'; data: NonNullable<Task['comments']>[number]; ts: string }
               | { type: 'activity'; data: Activity; ts: string }
@@ -78,12 +107,21 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
       style={{ position: 'fixed', inset: 0, background: '#00000040', zIndex: 100, display: 'flex', alignItems: 'flex-end', justifyContent: 'center' }}
     >
       <div
+        ref={sheetRef}
         className="slide-up"
-        style={{ background: '#f4f4f5', width: '100%', maxWidth: 520, borderRadius: '18px 18px 0 0', maxHeight: '92vh', overflowY: 'auto', boxShadow: '0 -4px 24px rgba(0,0,0,0.10)' }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        style={{
+          background: '#f4f4f5', width: '100%', maxWidth: 520, borderRadius: '18px 18px 0 0',
+          maxHeight: '92vh', overflowY: 'auto', boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
+          transform: dragY > 0 ? `translateY(${dragY}px)` : '',
+          transition: isDragging ? 'none' : 'transform 0.2s',
+        }}
       >
         {/* Handle + close */}
         <div style={{ position: 'sticky', top: 0, background: '#f4f4f5', padding: '14px 16px 10px', zIndex: 1 }}>
-          <div style={{ width: 36, height: 3, background: '#d4d4d8', borderRadius: 99, margin: '0 auto 14px' }} />
+          <div style={{ width: 40, height: 4, background: '#d4cfc8', borderRadius: 99, margin: '8px auto 8px' }} />
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <span style={{ fontSize: 15 }}>{CATEGORIES[current.category].icon}</span>

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -195,7 +195,7 @@ export function TasksPage() {
       </div>
 
       {/* Content */}
-      <div style={{ padding: '4px 12px 100px' }}>
+      <div style={{ padding: '4px 12px 140px' }}>
         {loading ? (
           <Spinner />
         ) : nonGroceryTasks.length === 0 ? (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,9 +36,9 @@ export const CATEGORIES: Record<Category, { label: string; icon: string; color: 
   repair: { label: 'Repair', icon: '🔧', color: '#ef4444' },
 }
 export const PRIORITIES: Record<Priority, { label: string; color: string }> = {
-  urgent: { label: 'Urgent', color: '#ef4444' },
-  high: { label: 'High', color: '#f97316' },
   normal: { label: 'Normal', color: '#6b7280' },
+  high: { label: 'High', color: '#f97316' },
+  urgent: { label: 'Urgent', color: '#ef4444' },
 }
 
 export type ActivityKind =


### PR DESCRIPTION
## Summary

Sprint 1 of planned UI/UX improvements — 5 critical fixes across frontend and one backend correctness fix surfaced by the QA audit.

### Frontend changes
- **FAB overlap**: task list `paddingBottom` increased to `140px` so the last card is never hidden behind the FAB + BottomNav
- **mPIN keypad**: fixed `useRef`-in-array-literal lint error; inputs and spinner correctly disabled while login is in-flight
- **Unassigned task avatar**: shows a neutral grey circle + "Unassigned" label instead of nothing
- **Priority pill order**: `PRIORITIES` reordered to `normal → high → urgent` (ascending severity) — affects TaskDrawer and AddTaskSheet
- **Swipe-to-close**: drag handle added to TaskDrawer; close triggers only when touch *ends* 80px below touch *start*, preventing accidental close on down-then-up gestures

### Backend changes (found during QA audit)
- `tasks.assignee_id` was `NOT NULL` + inner JOIN — tasks with no assignee were silently dropped from results
- Migration `000014` makes column nullable and changes FK to `ON DELETE SET NULL`
- `domain.Task.AssigneeID` is now `*uuid.UUID`; `Assignee` field no longer uses `omitempty` (serialises as `null`)
- All four repo query sites updated to `LEFT JOIN`; null-safe scanning
- Service + tests updated throughout

## Test plan
- [ ] `go build ./...` + `go vet ./...` — passes
- [ ] `go test ./...` with coverage ≥ 80% — 80.4% ✓
- [ ] `npm run build` — zero errors
- [ ] `npm run lint` — zero ESLint errors
- [ ] Pre-push hook passed: 80.4% coverage
- [ ] Verify unassigned tasks appear in list (previously dropped)
- [ ] Verify mPIN spinner shows and inputs are locked during login
- [ ] Verify swipe-to-close only triggers on genuine downward swipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)