### PR TITLE
feat: Sprint 3 — due-soon amber indicator + all-done undo toast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,8 +346,11 @@ Household-specific types (`Household`, `JoinRequest`, `HouseholdInvite`) live in
   - Text primary: `#1c1917`
   - Text secondary: `#78716c`
   - Text muted: `#a8a29e`
-  - Brand orange: `#f97316`
-  - Brand orange light: `#fff4ee`
+  - Indigo (primary interactive): `#6366f1`
+  - Indigo light (active backgrounds): `#eef2ff`
+  - Semantic orange `#f97316` — used only for Chore category and High priority data badges. Do not use for interactive chrome.
+  - Semantic red (overdue/error): `#ef4444` text, `#fecaca` light border
+  - Semantic amber (due-soon/warning): `#d97706` text, `#fde68a` border, `#fffbeb` pill background
 - Border radius convention: `8–10px` for small elements, `12–14px` for cards/inputs, `20–24px` for panels, `99px` for pills.
 - Font: `Fraunces, serif` for headings, system sans-serif for body text.
 - Transitions: `all .15s` or `background 0.2s` for interactive elements.

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Avatar } from '../ui/Avatar'
 import { CATEGORIES, PRIORITIES, type Task } from '../../types'
-import { formatDate, isOverdue } from '../../utils'
+import { formatDate, isOverdue, isDueSoon } from '../../utils'
 
 interface Props {
   task: Task
@@ -13,6 +13,7 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
   const [popping, setPopping] = useState(false)
   const cat = CATEGORIES[task.category]
   const overdue = isOverdue(task.due_at, task.done)
+  const dueSoon = isDueSoon(task.due_at, task.done)
 
   const handleToggle = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -29,7 +30,7 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
         borderRadius: 12,
         padding: '13px 14px 12px',
         marginBottom: 6,
-        border: `1px solid ${overdue && !task.done ? '#fecaca' : '#e4e4e7'}`,
+        border: `1px solid ${overdue && !task.done ? '#fecaca' : dueSoon && !task.done ? '#fde68a' : '#e4e4e7'}`,
         display: 'flex',
         gap: 11,
         alignItems: 'flex-start',
@@ -85,8 +86,14 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
         {((task.due_at && !task.done) || (task.comments?.length ?? 0) > 0) && (
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             {task.due_at && !task.done && (
-              <span style={{ fontSize: 11, fontWeight: 500, color: overdue ? '#ef4444' : '#71717a' }}>
-                {overdue ? '⚠ ' : ''}{formatDate(task.due_at)}
+              <span style={{
+                fontSize: 11, fontWeight: 500,
+                color: overdue ? '#ef4444' : dueSoon ? '#d97706' : '#71717a',
+                background: dueSoon && !overdue ? '#fffbeb' : 'transparent',
+                borderRadius: dueSoon && !overdue ? 4 : 0,
+                padding: dueSoon && !overdue ? '1px 5px' : '0',
+              }}>
+                {overdue ? '⚠ ' : dueSoon ? '⏰ ' : ''}{formatDate(task.due_at)}
               </span>
             )}
             {(task.comments?.length ?? 0) > 0 && (

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -23,7 +23,30 @@ export function TasksPage() {
   const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<Task | null>(null)
   const [showAdd, setShowAdd] = useState(false)
+  const [undoTask, setUndoTask] = useState<{ id: string } | null>(null)
+  const [undoTimer, setUndoTimer] = useState<ReturnType<typeof setTimeout> | null>(null)
   const refresh = useCallback(() => fetchTasks(), [fetchTasks])
+
+  const handleToggle = useCallback(async (id: string, done: boolean) => {
+    await toggleTask(id, done)
+    if (done) {
+      const openAfter = useStore.getState().tasks
+        .filter((t) => t.category !== 'grocery' && !t.done)
+      if (openAfter.length === 0) {
+        if (undoTimer) clearTimeout(undoTimer)
+        setUndoTask({ id })
+        const timer = setTimeout(() => {
+          setUndoTask(null)
+          setUndoTimer(null)
+        }, 4000)
+        setUndoTimer(timer)
+      }
+    } else if (undoTask?.id === id) {
+      if (undoTimer) clearTimeout(undoTimer)
+      setUndoTask(null)
+      setUndoTimer(null)
+    }
+  }, [toggleTask, undoTask, undoTimer])
 
   if (member && !member.household_id) {
     return <Navigate to="/household" replace />
@@ -234,7 +257,7 @@ export function TasksPage() {
             >Reset filters</button>
           </div>
         ) : visible.map((task) => (
-          <TaskCard key={task.id} task={task} onToggle={toggleTask} onOpen={setSelected} />
+          <TaskCard key={task.id} task={task} onToggle={handleToggle} onOpen={setSelected} />
         ))}
       </div>
 
@@ -263,6 +286,30 @@ export function TasksPage() {
       )}
       {showAdd && (
         <AddTaskSheet members={members} onClose={() => setShowAdd(false)} onAdded={refresh} />
+      )}
+      {undoTask && (
+        <div style={{
+          position: 'fixed', bottom: 80, left: '50%', transform: 'translateX(-50%)',
+          background: '#18181b', color: 'white', borderRadius: 10,
+          padding: '10px 16px', fontSize: 13, fontWeight: 500,
+          display: 'flex', alignItems: 'center', gap: 12,
+          boxShadow: '0 4px 16px rgba(0,0,0,0.20)', zIndex: 200,
+          whiteSpace: 'nowrap',
+        }}>
+          🎉 All tasks done!
+          <button
+            onClick={async () => {
+              if (undoTimer) clearTimeout(undoTimer)
+              await toggleTask(undoTask.id, false)
+              setUndoTask(null)
+              setUndoTimer(null)
+            }}
+            style={{
+              background: 'none', border: 'none', color: '#f97316',
+              fontWeight: 700, fontSize: 13, cursor: 'pointer', padding: 0,
+            }}
+          >Undo</button>
+        </div>
       )}
     </>
   )

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -19,3 +19,9 @@ export function isOverdue(dueAt: string | undefined, done: boolean): boolean {
 export function toDateInputValue(ts: string): string {
   return new Date(ts).toISOString().slice(0, 10)
 }
+
+export function isDueSoon(dueAt: string | undefined, done: boolean): boolean {
+  if (!dueAt || done) return false
+  const ms = new Date(dueAt).getTime() - Date.now()
+  return ms > 0 && ms <= 86_400_000
+}


### PR DESCRIPTION
## Summary

- **Due-soon amber indicator**: Tasks due within 24h (but not yet overdue) now show an amber `#fde68a` border and an ⏰ pill on the due-date span; overdue tasks remain red with ⚠; done tasks always show neutral border
- **All-done undo toast**: When the last non-grocery open task is toggled done, a "🎉 All tasks done!" toast appears with a 4-second auto-dismiss and an Undo button that reverts the last toggle
- **Palette docs updated**: CLAUDE.md now documents the indigo primary interactive color, semantic amber tokens (due-soon), and semantic red tokens (overdue) with usage constraints

## QA Fixes (caught in review)

- Removed redundant `t.id !== id` filter in `handleToggle` — since `toggleTask` applies an optimistic update synchronously, the task's `done=true` is already reflected in the store before the filter runs
- Added `await` to the Undo button's `onClick` handler so toast cleanup only fires after the toggle API call confirms

## Test plan

- [ ] Add a task due today (within 24h) → card shows amber border and ⏰ pill
- [ ] Add a task due yesterday → card shows red border and ⚠ icon
- [ ] Mark a task done → no amber/red indicators shown for done tasks
- [ ] Toggle last non-grocery open task done → undo toast appears, auto-dismisses after ~4s
- [ ] Click Undo in toast → task reverts to open, toast dismisses
- [ ] Toggle the task back open manually → toast and timer clear
- [ ] Grocery tasks don't count toward the all-done trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)