### PR TITLE
fix: error feedback sweep (Sprint 4)

### DIFF
--- a/frontend/src/components/layout/AccountMenu.tsx
+++ b/frontend/src/components/layout/AccountMenu.tsx
@@ -23,6 +23,7 @@ export function AccountMenu() {
   const [editAvatar, setEditAvatar] = useState('')
   const [editColor, setEditColor] = useState('')
   const [saveBusy, setSaveBusy] = useState(false)
+  const [saveProfileError, setSaveProfileError] = useState<string | null>(null)
 
   const [pinCurrent, setPinCurrent] = useState('')
   const [pinNew, setPinNew] = useState('')
@@ -48,6 +49,7 @@ export function AccountMenu() {
     setEditName(member.name)
     setEditAvatar(member.avatar)
     setEditColor(member.color)
+    setSaveProfileError(null)
     setSheet('profile')
   }
 
@@ -62,10 +64,13 @@ export function AccountMenu() {
   const handleSaveProfile = async () => {
     if (!editName.trim()) return
     setSaveBusy(true)
+    setSaveProfileError(null)
     try {
       const updated = await membersApi.updateMe({ name: editName.trim(), avatar: editAvatar, color: editColor })
       updateMember(updated)
       closeSheet()
+    } catch {
+      setSaveProfileError('Could not save profile. Please try again.')
     } finally {
       setSaveBusy(false)
     }
@@ -226,6 +231,12 @@ export function AccountMenu() {
                   fontSize: 14, outline: 'none', background: '#f9f9f9', boxSizing: 'border-box', marginBottom: 20, color: '#1c1917',
                 }}
               />
+
+              {saveProfileError && (
+                <div style={{ padding: '8px 12px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca', marginBottom: 12 }}>
+                  {saveProfileError}
+                </div>
+              )}
 
               <div style={{ display: 'flex', gap: 8 }}>
                 <button type="button" onClick={closeSheet} style={{

--- a/frontend/src/components/members/HouseholdPanel.tsx
+++ b/frontend/src/components/members/HouseholdPanel.tsx
@@ -295,14 +295,18 @@ export function HouseholdPanel() {
       await householdsApi.approveRequest(id)
       setRequests((prev) => prev.filter((r) => r.id !== id))
       await fetchMembers()
-    } catch {}
+    } catch {
+      setError('Could not approve request. Please try again.')
+    }
   }
 
   const handleReject = async (id: string) => {
     try {
       await householdsApi.rejectRequest(id)
       setRequests((prev) => prev.filter((r) => r.id !== id))
-    } catch {}
+    } catch {
+      setError('Could not reject request. Please try again.')
+    }
   }
 
   // No household: setup screen
@@ -576,6 +580,12 @@ export function HouseholdPanel() {
       {message && (
         <div style={{ padding: '10px 14px', borderRadius: 8, background: '#f0fdf4', color: '#15803d', fontSize: 12, border: '1px solid #bbf7d0', marginBottom: 12 }}>
           {message}
+        </div>
+      )}
+
+      {error && (
+        <div style={{ padding: '10px 14px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca', marginBottom: 12 }}>
+          {error}
         </div>
       )}
 

--- a/frontend/src/components/members/MembersScreen.tsx
+++ b/frontend/src/components/members/MembersScreen.tsx
@@ -20,16 +20,18 @@ export function MembersScreen({ tasks, members, currentMember, isAdmin }: Props)
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null)
   const [promoting, setPromoting] = useState<string | null>(null)
   const [flashSuccess, setFlashSuccess] = useState<string | null>(null)
+  const [memberError, setMemberError] = useState<{ id: string; msg: string } | null>(null)
 
   const handlePromote = async (id: string) => {
     setPromoting(id)
+    setMemberError(null)
     try {
       await householdsApi.promoteMember(id)
       setFlashSuccess(id)
       setTimeout(() => setFlashSuccess(null), 800)
       await fetchMembers()
     } catch {
-      // no-op
+      setMemberError({ id, msg: 'Could not promote member. Please try again.' })
     } finally {
       setPromoting(null)
     }
@@ -38,11 +40,12 @@ export function MembersScreen({ tasks, members, currentMember, isAdmin }: Props)
   const handleRemove = async (id: string) => {
     setConfirmRemove(null)
     setRemoving(id)
+    setMemberError(null)
     try {
       await householdsApi.removeMember(id)
       await fetchMembers()
     } catch {
-      // no-op
+      setMemberError({ id, msg: 'Could not remove member. Please try again.' })
     } finally {
       setRemoving(null)
     }
@@ -61,7 +64,7 @@ export function MembersScreen({ tasks, members, currentMember, isAdmin }: Props)
             className={flashSuccess === m.id ? 'flash-green' : undefined}
             style={{ background: 'white', borderRadius: 12, padding: 16, border: '1px solid #ede8e1', marginBottom: 8 }}
           >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: open.length > 0 ? 12 : 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: open.length > 0 || memberError?.id === m.id ? 12 : 0 }}>
               <Avatar member={m} size={40} />
               <div style={{ flex: 1 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
@@ -118,6 +121,11 @@ export function MembersScreen({ tasks, members, currentMember, isAdmin }: Props)
                 </div>
               )}
             </div>
+            {memberError?.id === m.id && (
+              <div style={{ padding: '6px 10px', borderRadius: 7, background: '#fef2f2', color: '#ef4444', fontSize: 11, border: '1px solid #fecaca', marginBottom: open.length > 0 ? 8 : 0 }}>
+                {memberError.msg}
+              </div>
+            )}
             {open.length > 0 && (
               <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                 {open.slice(0, 3).map((t) => (

--- a/frontend/src/components/tasks/AddTaskSheet.tsx
+++ b/frontend/src/components/tasks/AddTaskSheet.tsx
@@ -83,6 +83,7 @@ export function AddTaskSheet({ members, onClose, onAdded }: Props) {
     household_id: member?.household_id ?? '',
   })
   const [saving, setSaving] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   const set = <K extends keyof CreateTaskPayload>(k: K, v: CreateTaskPayload[K]) =>
     setForm((f) => ({ ...f, [k]: v }))
@@ -98,10 +99,13 @@ export function AddTaskSheet({ members, onClose, onAdded }: Props) {
   const submit = async () => {
     if (!form.title.trim()) return
     setSaving(true)
+    setSubmitError(null)
     try {
       await createTask(form)
       onAdded()
       onClose()
+    } catch {
+      setSubmitError('Could not add task. Please try again.')
     } finally {
       setSaving(false)
     }
@@ -195,6 +199,12 @@ export function AddTaskSheet({ members, onClose, onAdded }: Props) {
             }}>{m.name}</button>
           ))}
         </div>
+
+        {submitError && (
+          <div style={{ padding: '8px 12px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca', marginBottom: 10 }}>
+            {submitError}
+          </div>
+        )}
 
         <button
           onClick={submit}

--- a/frontend/src/components/tasks/TaskDrawer.tsx
+++ b/frontend/src/components/tasks/TaskDrawer.tsx
@@ -19,9 +19,12 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
   const [comment, setComment] = useState('')
   const [sendingComment, setSendingComment] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
   const [activities, setActivities] = useState<Activity[]>([])
-  const addComment = useStore((s) => s.addComment)
+  const { addComment, deleteTask } = useStore()
   const { member: authMember } = useAuthStore()
   const me = members.find((m) => m.id === authMember?.id) ?? members[0]
 
@@ -35,12 +38,17 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
   useEffect(() => { fetchActivities() }, [fetchActivities])
 
   const patch = async (payload: UpdateTaskPayload) => {
+    const previous = current
     setSaving(true)
+    setSaveError(null)
     try {
       const updated = await tasksApi.update(current.id, payload)
       setCurrent(updated)
       onUpdated(updated)
       fetchActivities()
+    } catch {
+      setCurrent(previous)
+      setSaveError('Could not save change. Please try again.')
     } finally {
       setSaving(false)
     }
@@ -59,6 +67,21 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
       setComment(body)
     } finally {
       setSendingComment(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await deleteTask(current.id)
+      onDeleted(current.id)
+      onClose()
+    } catch {
+      setDeleteError('Could not delete task. Please try again.')
+      setConfirmDelete(false)
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -276,6 +299,16 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
 
         {/* Danger zone */}
         <div style={{ margin: '0 10px 36px' }}>
+          {saveError && (
+            <div style={{ padding: '8px 12px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca', marginBottom: 10 }}>
+              {saveError}
+            </div>
+          )}
+          {deleteError && (
+            <div style={{ padding: '8px 12px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca', marginBottom: 10 }}>
+              {deleteError}
+            </div>
+          )}
           {confirmDelete ? (
             <div style={{ display: 'flex', gap: 8 }}>
               <button
@@ -283,9 +316,10 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
                 style={{ flex: 1, background: 'white', border: '1px solid #ede8e1', borderRadius: 10, padding: 12, color: '#78716c', fontWeight: 600, fontSize: 14, cursor: 'pointer' }}
               >Cancel</button>
               <button
-                onClick={() => { onDeleted(current.id); onClose() }}
-                style={{ flex: 1, background: '#ef4444', border: 'none', borderRadius: 10, padding: 12, color: 'white', fontWeight: 700, fontSize: 14, cursor: 'pointer' }}
-              >Delete</button>
+                onClick={handleDelete}
+                disabled={deleting}
+                style={{ flex: 1, background: deleting ? '#fca5a5' : '#ef4444', border: 'none', borderRadius: 10, padding: 12, color: 'white', fontWeight: 700, fontSize: 14, cursor: deleting ? 'not-allowed' : 'pointer' }}
+              >{deleting ? 'Deleting…' : 'Delete'}</button>
             </div>
           ) : (
             <button

--- a/frontend/src/pages/GroceryPage.tsx
+++ b/frontend/src/pages/GroceryPage.tsx
@@ -25,6 +25,7 @@ export function GroceryPage() {
   const [newTitle, setNewTitle] = useState('')
   const [newQty, setNewQty] = useState('')
   const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const load = async () => {
@@ -46,6 +47,7 @@ export function GroceryPage() {
     const title = newTitle.trim()
     if (!title) return
     setAdding(true)
+    setAddError(null)
     try {
       const payload: Parameters<typeof tasksApi.create>[0] = {
         title, notes: '', category: 'grocery', priority: 'normal',
@@ -58,6 +60,8 @@ export function GroceryPage() {
       setNewTitle('')
       setNewQty('')
       inputRef.current?.focus()
+    } catch {
+      setAddError('Could not add item. Please try again.')
     } finally {
       setAdding(false)
     }
@@ -255,6 +259,11 @@ export function GroceryPage() {
           }}
         />
       </div>
+      {addError && (
+        <div style={{ margin: '0 12px 8px', padding: '8px 12px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca' }}>
+          {addError}
+        </div>
+      )}
 
       {active.length > 1 && (
         <div style={{ padding: '0 12px 8px', display: 'flex', justifyContent: 'flex-end' }}>

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -77,8 +77,14 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   deleteTask: async (id) => {
+    const previous = get().tasks.find((t) => t.id === id)
     set((s) => ({ tasks: s.tasks.filter((t) => t.id !== id) }))
-    await tasksApi.remove(id)
+    try {
+      await tasksApi.remove(id)
+    } catch {
+      if (previous) set((s) => ({ tasks: [previous, ...s.tasks] }))
+      throw new Error('Failed to delete task')
+    }
   },
 
   addComment: async (taskId, authorId, body) => {


### PR DESCRIPTION
## Summary

- **#60 / #64 TaskDrawer**: `patch()` now reverts `current` to previous state on API failure and shows a red `saveError` banner; delete button replaced with async `handleDelete()` that uses `store.deleteTask`, shows `deleteError` on failure
- **#66 store.deleteTask**: optimistic remove + revert task to front of list + rethrow on API failure
- **#62 AddTaskSheet**: `submit()` catch shows `submitError` banner above the submit button
- **#62 GroceryPage**: `handleAdd()` catch shows `addError` banner below the input row
- **#65 MembersScreen**: `handlePromote`/`handleRemove` catch sets per-card `memberError` displayed inline in the member card
- **#79 HouseholdPanel**: `handleApprove`/`handleReject` catch routes into the existing `error` state, displayed as a red banner in the household section
- **#78 AccountMenu**: `handleSaveProfile` catch sets `saveProfileError` displayed above the Cancel/Save buttons in the profile sheet

## Test plan

- [ ] `npm run build` passes (verified)
- [ ] `npm run lint` passes (verified)
- [ ] `go build ./...` + `go vet ./...` pass (verified)
- [ ] Pre-commit hook passes (verified)
- [ ] Simulate API failure on task patch: title input blur should revert to old value and show red banner
- [ ] Simulate delete failure: should show error and close confirm dialog
- [ ] Simulate add-task failure in AddTaskSheet: red banner visible above submit button
- [ ] Simulate add-grocery failure in GroceryPage: red banner below input row
- [ ] Simulate promote/remove failure in MembersScreen: red banner inside member card
- [ ] Simulate approve/reject failure in HouseholdPanel: red banner in household section
- [ ] Simulate profile save failure in AccountMenu: red banner above Cancel/Save buttons

Closes #60 #62 #64 #65 #66 #78 #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)