### PR TITLE
feat: enrich /health endpoint — commit, env, db, uptime

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,10 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o server ./cmd/server
+RUN BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) && \
+    CGO_ENABLED=0 GOOS=linux go build \
+      -ldflags="-s -w -X main.BuildTime=${BUILD_TIME}" \
+      -o server ./cmd/server
 
 # ── Runtime image ──────────────────────────────────────────────
 FROM alpine:3.21

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -8,6 +8,9 @@ import (
 	"github.com/homejira/api/internal/server"
 )
 
+// Injected at build time via -ldflags "-X main.BuildTime=<timestamp>"
+var BuildTime = "unknown"
+
 func main() {
 	cfg := config.Load()
 
@@ -25,7 +28,7 @@ func main() {
 	}
 
 	// ── Server ────────────────────────────────────────────────────
-	srv := server.New(&cfg, pool)
+	srv := server.New(&cfg, pool, BuildTime)
 
 	if err := srv.Start(); err != nil {
 		log.Fatalf("server error: %v", err)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -25,7 +28,7 @@ type Server struct {
 	cfg    *config.Config
 }
 
-func New(cfg *config.Config, db *pgxpool.Pool) *Server {
+func New(cfg *config.Config, db *pgxpool.Pool, buildTime string) *Server {
 	// ── Dependency Injection ──────────────────────────────────────
 	memberRepo := repository.NewMemberRepository(db)
 	taskRepo := repository.NewTaskRepository(db)
@@ -78,9 +81,26 @@ func New(cfg *config.Config, db *pgxpool.Pool) *Server {
 		MaxAge:           300,
 	}))
 
-	// Health check
+	// Health check — includes build metadata and DB ping for deployment verification
+	startTime := time.Now()
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"status":"ok"}`))
+		dbStatus := "ok"
+		if err := db.Ping(context.Background()); err != nil {
+			dbStatus = "error: " + err.Error()
+		}
+		commit := os.Getenv("RAILWAY_GIT_COMMIT_SHA")
+		if commit == "" {
+			commit = "dev"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":     "ok",
+			"env":        cfg.Env,
+			"commit":     commit,
+			"built_at":   buildTime,
+			"uptime_sec": int(time.Since(startTime).Seconds()),
+			"db":         dbStatus,
+		})
 	})
 
 	// API v1


### PR DESCRIPTION
Promotes staging → main.

Enriches \`GET /health\` with \`commit\` (RAILWAY_GIT_COMMIT_SHA), \`built_at\` (ldflags), \`db\` (live ping), \`uptime_sec\`, \`env\`. Enables deployment verification: poll until commit matches expected SHA before smoke tests.

Also covers the missing migration 000015 (quantity column) from the previous hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)