### PR TITLE
docs: comprehensive md sync — Sprint 4 complete, rules updated, API corrected

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,17 +4,29 @@
 
 ## Why
 
-<!-- Why is this change needed? Link to backlog item if applicable (e.g. NE-08, UX-12). -->
+<!-- Why is this change needed? Link to GitHub issue if applicable (e.g. #42, #44). -->
 
 ## How
 
 <!-- Brief description of the approach taken. -->
 
-## Test plan
+## Checklist
 
 - [ ] Tested locally (`make up`)
 - [ ] No regressions on existing flows
-- [ ] Migration applied and rolled back cleanly (if schema change)
+- [ ] Migration added and tested up + down (if schema change)
+- [ ] `COALESCE(col, '')` used for any nullable TEXT columns in new SELECT/RETURNING queries
+- [ ] Postman collection updated (if API routes/shapes changed) — `postman/HomeJira.postman_collection.json`
+- [ ] `go build ./...` and `go vet ./...` pass
+- [ ] `npm run build` and `npm run lint` pass
+
+## QA Sign-off
+
+<!-- Invoke /qa1 (backend) and/or /qa2 (frontend) before requesting merge.
+     QA agent will post "QA-1 ✅" or "QA-2 ✅" as a comment. -->
+
+- [ ] QA-1 sign-off (backend / API changes)
+- [ ] QA-2 sign-off (frontend / UI changes)
 
 ## Screenshots (if UI change)
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -58,6 +58,16 @@ UX-18 Stats "By member" hidden when 0 members · UX-19 Stats urgency summary row
 Due-soon amber pill on TaskCard · All-done undo toast (3 s) with household celebration state ·
 Onboarding indicator for new households · Palette documentation
 
+#### Sprint 4 (Stability) — `done`
+NE-09 Grocery quantity field (free-text, migration + full stack) ·
+Palette sweep: warm neutrals across all screens, JoinPage brand chrome ·
+App.tsx default export violation fixed ·
+Error feedback sweep: TaskDrawer, deleteTask optimistic revert, GroceryPage, MembersScreen, AccountMenu, HouseholdPanel ·
+Backend bug fixes: null vs [] for empty collections, join-by-code 500, link/join idempotency, POST /members phone NOT NULL ·
+Postman collection sync + pre-commit hook ·
+Enriched /health endpoint (commit SHA, env, DB ping, uptime, build time) ·
+Phone NULL scan fix in member_repo (COALESCE on all SELECT/RETURNING)
+
 ---
 
 ### 🎨 Design
@@ -125,3 +135,11 @@ Platform-specific share sheet using `navigator.share` with WhatsApp/iMessage fal
 | — | Postman collection — 39-request v2.1 collection at `postman/HomeJira.postman_collection.json`; pre-commit hook enforces collection sync on API changes; CLAUDE.md rule 18 | 2026-03-09 |
 | — | FigJam diagrams — System Architecture, Auth Flow, Task Lifecycle, Household Membership, TasksPage+TaskDrawer wireframe, Auth Screens wireframe | 2026-03-09 |
 | — | Backlog migrated to GitHub Issues (issues #42–#54) | 2026-03-09 |
+| NE-09 | Grocery quantity field — free-text, migration 000015, full stack | 2026-03-09 |
+| — | Sprint 4 palette sweep — warm neutrals, JoinPage chrome, App.tsx named export | 2026-03-09 |
+| — | Sprint 4 error feedback — TaskDrawer, deleteTask revert, GroceryPage, MembersScreen, AccountMenu, HouseholdPanel | 2026-03-09 |
+| — | Backend bug fixes — null→[], join-by-code 500, link/join idempotency, phone NOT NULL | 2026-03-09 |
+| — | /health endpoint enriched — commit SHA, env, DB ping, uptime, build time via ldflags | 2026-03-09 |
+| — | Phone NULL scan fix — COALESCE(phone,'') in all member_repo SELECT/RETURNING | 2026-03-09 |
+| — | Sprint 4 retro filed as GitHub issue #96 | 2026-03-09 |
+| — | Test account created in production: +15550000001 / mPIN 1234 | 2026-03-09 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,12 +92,13 @@ homejira/
         │   ├── authStore.ts        # Zustand auth store (token, member, guest)
         │   └── guest.ts            # guest-mode localStorage helpers
         ├── components/
-        │   ├── ui/                 # Badge, Avatar, Chip, Spinner
+        │   ├── ui/                 # Badge, Avatar, Chip, Spinner, AppLogo
         │   ├── layout/             # AppLayout, BottomNav, GuestBanner, AccountMenu
         │   ├── tasks/              # TaskCard, TaskDrawer, AddTaskSheet
-        │   ├── members/            # MembersScreen, HouseholdPanel
+        │   ├── members/            # MembersScreen, HouseholdPanel, HouseholdPromo
+        │   ├── stats/              # StatsScreen
         │   └── auth/               # PhoneStep, MPINStep, RegisterStep
-        ├── pages/                  # TasksPage, StatsPage, MembersPage, AuthPage
+        ├── pages/                  # TasksPage, StatsPage, MembersPage, GroceryPage, AuthPage, ReferralPage
         ├── types/index.ts          # all TS interfaces and enum-like const maps
         └── utils/index.ts          # pure utility functions (timeAgo, etc.)
 ```
@@ -255,7 +256,7 @@ func (h *ThingHandler) Get(w http.ResponseWriter, r *http.Request) {
 - `middleware.ClaimsFromContext(ctx)` retrieves it.
 - Claims fields: `MemberID`, `Phone`, `Name`, `Avatar`, `Color`, `HouseholdID` (empty string if not in a household).
 - All `/api/v1` routes except `/auth/*` are inside the `r.Group(func(r chi.Router) { r.Use(middleware.RequireAuth(authSvc)) ... })` block.
-- JWT TTL is 30 days. Token includes `household_id` so household context is available without a DB lookup.
+- JWT TTL is 7 days. Token includes `household_id` so household context is available without a DB lookup.
 
 ### Router (server.go)
 
@@ -494,22 +495,30 @@ Pages are route-level components in `src/pages/`. They:
     **Production API:** `https://homejira.up.railway.app/api/v1`
 
     ```bash
-    # 1. Public config endpoint responds 200 with flags object
+    # 1. Health endpoint — DB ok, commit SHA present
+    curl -s "$API/../health"                                   # → 200 {"status":"ok","db":"ok",...}
+
+    # 2. Public config endpoint responds 200 with flags object
     curl -s "$API/config"                                      # → 200 {"flags":{...}}
 
-    # 2. Auth guard active — unauthenticated requests return 401
+    # 3. Auth guard active — unauthenticated requests return 401
     curl -s -o /dev/null -w "%{http_code}" "$API/tasks"        # → 401
     curl -s -o /dev/null -w "%{http_code}" "$API/members"      # → 401
 
-    # 3. Known-bad join code returns 401 (auth gate) — NOT 500
+    # 4. Known-bad join code returns 401 (auth gate) — NOT 500
     curl -s -o /dev/null -w "%{http_code}" -X POST \
       -H "Content-Type: application/json" \
       -d '{"code":"XXXXXX"}' "$API/households/join-by-code"   # → 401 (not 500)
 
-    # 4. /auth/check public route exists
+    # 5. /auth/check-phone public route exists (path is check-phone, not check)
     curl -s -o /dev/null -w "%{http_code}" -X POST \
       -H "Content-Type: application/json" \
-      -d '{"phone":"+10000000000"}' "$API/auth/check"         # → 200/404/422 (not 500)
+      -d '{"phone":"+10000000000"}' "$API/auth/check-phone"   # → 200 (not 500)
     ```
 
     Any 5xx response is a release blocker — roll back and investigate before proceeding.
+    Use the full 16-check smoke suite in the session history for thorough post-deploy verification.
+
+20. **All PRs touching backend or frontend code require QA sign-off before merge.** Backend-only PRs: invoke QA-1 (`/qa1`). Frontend-only: invoke QA-2 (`/qa2`). Full-stack: both. QA agent posts a sign-off comment ("QA-1 ✅" or "QA-2 ✅") on the PR. No merge without sign-off.
+
+21. **Nullable TEXT columns scanned into Go `string` must use `COALESCE(col, '')`.** When a TEXT column is nullable in the DB schema, never scan it directly into a non-pointer Go `string` — it will panic on NULL rows. Use `COALESCE(col, '')` in every SELECT/RETURNING query that includes that column. Apply this to all queries for that column, not just new ones.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
 
 ## Features
 
-- **Auth** — phone number + 4-digit MPIN, JWT (30-day TTL), rate-limited login, change PIN in-app
+- **Auth** — phone number + 4-digit MPIN, JWT (7-day TTL), rate-limited login, change PIN in-app
 - **Households** — create or join by code; invite by share link; admin controls (promote, remove, approve/reject join requests); leave household; delete group
 - **Tasks** — full CRUD, category (chore/errand/repair), priority (urgent/high/normal), assignee, due date, notes, search and filter
-- **Grocery list** — dedicated checklist view with quick-add, check-all, clear done, and history grouped by day
+- **Grocery list** — dedicated checklist view with quick-add, quantity field, check-all, clear done, and history grouped by day
 - **Live sync** — SSE streams push updates to all household members instantly, no polling
 - **Activity history** — every task change (created, completed, assigned, priority/category/title/notes/due changed) recorded in a unified timeline alongside comments
 - **Stats** — completion ring, per-category progress bars, per-member breakdown
@@ -74,11 +74,27 @@ make ps          List running containers
 
 ## Service URLs
 
+### Local (dev)
+
 | Service   | URL                          |
 |-----------|------------------------------|
 | Frontend  | http://localhost:3000        |
 | API       | http://localhost:8080/api/v1 |
 | Database  | localhost:5432               |
+
+### Staging
+
+| Service   | URL                                                             |
+|-----------|-----------------------------------------------------------------|
+| Frontend  | https://homejira-git-staging-vibeoskis-projects.vercel.app     |
+| API       | https://homejira-staging.up.railway.app/api/v1                 |
+
+### Production
+
+| Service   | URL                                        |
+|-----------|--------------------------------------------|
+| Frontend  | https://homejira.app                       |
+| API       | https://homejira.up.railway.app/api/v1     |
 
 ---
 
@@ -216,12 +232,17 @@ All endpoints require `Authorization: Bearer <jwt>` unless noted.
 | POST   | `/tasks/:id/comments`        | Add comment                              |
 | GET    | `/tasks/:id/activity`        | Get activity history                     |
 
+### Health
+
+| Method | Endpoint   | Auth | Description                                      |
+|--------|------------|------|--------------------------------------------------|
+| GET    | `/health`  | No   | Liveness check — commit SHA, env, DB ping, uptime |
+
 ### Members
 
 | Method | Endpoint                    | Description                     |
 |--------|-----------------------------|---------------------------------|
 | GET    | `/members`                  | List household members          |
-| POST   | `/members`                  | Create standalone member        |
 | GET    | `/members/:id`              | Get member                      |
 | PATCH  | `/members/me`               | Update profile                  |
 | GET    | `/members/me/coins`         | Get coin balance + history      |
@@ -287,10 +308,21 @@ All endpoints require `Authorization: Bearer <jwt>` unless noted.
 
 See [BACKLOG.md](./BACKLOG.md) for the full prioritised backlog.
 
-**Up next:**
-- Due date reminders (push notifications)
-- Recurring tasks
-- Shopping list aggregation
+**Open bugs (Sprint 5):**
+- #70 JoinPage: authenticated auto-join does not refresh JWT (stale household_id)
+- #71 JoinPage: "Sign in" button calls sign-up handler
+- #72 AccountMenu: avatar shows emoji instead of letter
+- #73 TasksPage: heading not using Fraunces font
+- #74 TasksPage: undo toast uses orange (palette violation)
+- #75 AddTaskSheet: empty household_id fallback on task create
+- #76 Loading state not shown on SSE-triggered refresh
+- #77 UX polish audit follow-up
+
+**Up next (roadmap):**
+- #42 In-app notification feed (NE-08)
+- #44 Recurring tasks (NE-10)
+- #48 Push notifications (Web Push API)
+- #45 PWA — installable, offline
 
 ---
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -50,7 +50,7 @@ The app is mobile-first, lightweight, and designed to be picked up with no onboa
 ## 3. Core Concepts
 
 ### Members
-A **member** is a user account. Every member has a name, a profile color, an emoji avatar, and a phone number. Members authenticate with a 4-digit mPIN (similar to a phone PIN). There are no passwords or email addresses required to use the app.
+A **member** is a user account. Every member has a name, a profile color, a letter avatar (first letter of name on a colored background), and a phone number. Members authenticate with a 4-digit mPIN (similar to a phone PIN). There are no passwords or email addresses required to use the app.
 
 ### Households
 A **household** is the central container. Tasks, members, and activities all belong to a household. A member can only belong to one household at a time. The person who creates the household becomes the **admin**.
@@ -82,7 +82,7 @@ HomeJira uses **phone + 4-digit mPIN** authentication — no email, no password,
 
 ### Security
 - mPINs are **bcrypt-hashed** before storage. The raw PIN is never saved or logged.
-- Authentication returns a **JWT** (JSON Web Token) with a 7-day TTL. The token includes your member ID, name, avatar, color, and household ID.
+- Authentication returns a **JWT** (JSON Web Token) with a **7-day TTL**. The token includes your member ID, name, avatar, color, and household ID.
 - All protected API calls require a valid `Authorization: Bearer <token>` header.
 - The server validates the token on every request and confirms the member exists in the database.
 
@@ -144,6 +144,7 @@ Tasks are the core of HomeJira. Every task belongs to a household and optionally
 | **Priority** | `urgent`, `high`, or `normal` |
 | **Assignee** | Which member is responsible (optional) |
 | **Due date** | When it should be done by (optional) |
+| **Quantity** | Free-text amount (grocery items only, optional) |
 | **Done** | Completed or not |
 
 ### Creating a Task
@@ -197,6 +198,7 @@ The Grocery List is a dedicated view for all tasks with the `grocery` category. 
 
 ### Features
 - **Quick add** — type an item at the top and tap Add (or press Enter)
+- **Quantity field** — optionally set a free-text quantity (e.g. "2 litres", "6 pack") on each grocery item
 - **Check off items** — tap any item to mark it as bought
 - **Check all** — bulk-complete all active items in one tap
 - **Inline edit** — tap an item's text to edit it in place
@@ -252,12 +254,14 @@ Activities are combined with comments into a single chronological feed in the ta
 ### Profile Information
 Each member has:
 - **Name** — displayed throughout the app
-- **Emoji avatar** — chosen from 18 options (people and animals)
+- **Letter avatar** — first letter of name on a colored circle background (Google-style). Emoji selection during registration is stored but displayed as a letter avatar throughout the app.
 - **Color** — chosen from 8 colors; used for avatar background, task indicators, and UI accents
 - **Phone number** — used for authentication; shown in your own profile view
 
 ### Letter Avatars
 Avatars are displayed as a colored circle with the **first letter of the member's name** — Google-style. The background color is the member's chosen profile color. This makes members immediately recognisable at a glance across task cards, comments, and member lists.
+
+> Note: The registration screen asks for an emoji selection, which is stored in the database. The letter avatar is the canonical display format used throughout the app interface.
 
 ### Editing Your Profile
 From the account menu (top-right), tap **Edit profile**:
@@ -406,12 +410,17 @@ All endpoints are prefixed with `/api/v1`.
 |--------|------|------|-------------|
 | `GET` | `/config` | — | Get app feature flags |
 
+### Health
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/health` | — | Liveness check — commit SHA, env, DB ping, uptime, build time |
+
 ### Members
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/members` | ✅ | List all members in household |
-| `POST` | `/members` | ✅ | Create a member |
 | `PATCH` | `/members/me` | ✅ | Update own profile (name, avatar, color) |
 | `GET` | `/members/{id}` | ✅ | Get member by ID |
 | `GET` | `/members/me/coins` | ✅ | Get coin balance + transaction history |


### PR DESCRIPTION
## What
Syncs all markdown documentation to reflect current codebase state after Sprint 4 and post-sprint hotfixes.

## Changes

**CLAUDE.md** — Fix JWT TTL 30d→7d, add Rule 20 (QA sign-off), Rule 21 (COALESCE nullable TEXT), fix smoke test path, update layout tree

**README.md** — Fix JWT TTL, remove `POST /members` (doesn't exist), add `GET /health`, add quantity to features, add staging/prod URL tables, update roadmap

**BACKLOG.md** — Add Sprint 4 done items and hotfixes to changelog

**docs/PRODUCT.md** — Fix emoji→letter avatar, add quantity field, remove `POST /members`, add `GET /health`

**.github/pull_request_template.md** — Add QA sign-off checkboxes, expand checklist

## Test plan
- [ ] Docs only — no code changed