### PR TITLE
ci: block PRs to main from non-staging branches

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,21 @@
+name: Protect main — staging only
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: Source must be staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR originates from staging
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "❌ PRs to main must come from the staging branch."
+            echo "   Source branch: ${{ github.head_ref }}"
+            echo ""
+            echo "   Workflow: branch off staging → PR to staging → merge staging → main"
+            exit 1
+          fi
+          echo "✅ Source branch is staging — OK"


### PR DESCRIPTION
Adds `.github/workflows/protect-main.yml` — a required status check that fails if a PR to `main` comes from any branch other than `staging`. Also registered as a required check in branch protection settings.

Prevents Dependabot and feature branches from merging directly to main, enforcing the workflow: `feature/*` → `staging` → `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)