### PR TITLE
ci: auto-backmerge main→staging + sync current divergence

### DIFF
--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -1,0 +1,75 @@
+name: Sync main → staging
+
+# After any push to main, ensure staging gets those commits back.
+# Prevents staging→main conflicts caused by commits that bypass staging
+# (promotion merge commits, emergency hotfixes, etc.).
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  backmerge:
+    name: Back-merge main into staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if staging already contains main
+        id: check
+        run: |
+          git fetch origin staging main
+          if git merge-base --is-ancestor origin/main origin/staging; then
+            echo "Staging already contains all of main — nothing to do."
+            echo "in_sync=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "main has commits staging does not — backmerge needed."
+            echo "in_sync=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create sync branch and PR
+        if: steps.check.outputs.in_sync == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA="${{ github.sha }}"
+          SHORT="${SHA:0:7}"
+          BRANCH="sync/main-into-staging-${SHORT}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH" origin/staging
+
+          if git merge origin/main --no-edit; then
+            git push origin "$BRANCH"
+            PR_URL=$(gh pr create \
+              --title "sync: back-merge main into staging (${SHORT})" \
+              --body "$(cat <<'EOF'
+Automatic back-merge triggered by a push to \`main\` that staging did not yet contain.
+
+This keeps \`staging\` and \`main\` in sync so the next \`staging → main\` promotion is conflict-free.
+
+**Merge strategy:** regular merge (not squash) to preserve full history.
+EOF
+)" \
+              --base staging \
+              --head "$BRANCH")
+            echo "PR created: $PR_URL"
+            gh pr merge "$BRANCH" --merge --auto
+          else
+            # Conflicts — push the branch and open a PR for manual resolution
+            git merge --abort
+            git checkout "$BRANCH"
+            git push origin "$BRANCH"
+            gh pr create \
+              --title "sync: back-merge main into staging (${SHORT}) — CONFLICTS" \
+              --body "Automatic back-merge of \`main\` into \`staging\` has conflicts that need manual resolution. Please resolve and merge to keep branches in sync." \
+              --base staging \
+              --head "$BRANCH" \
+              --label "needs-review"
+            echo "Conflict PR created — manual resolution required."
+          fi


### PR DESCRIPTION
## What

Two things in one PR:

1. **Immediate sync**: fast-forward merges main (`84f5a86`) into staging — resolves the divergence from PR #140 (fix/promote-to-main-mar14 → main).

2. **`sync-main-to-staging.yml` workflow**: after every future push to main, GitHub Actions checks if staging contains all of main's commits. If not, it auto-creates a `sync/main-into-staging-{sha}` branch, merges main in, opens a PR to staging, and auto-merges if clean. Conflict PRs are opened for manual resolution.

## Why this prevents future conflicts

The squash-merge divergence happens when a commit lands on main without going through staging first (Dependabot old config, promotion fix branches). With this workflow:
- New commit lands on main → workflow fires within ~30s → staging gets it back automatically
- Next staging→main PR always fast-forwards cleanly

Combined with:
- Dependabot already targeting `staging` ✅
- `protect-main.yml` blocking non-staging PRs to main ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)