### PR TITLE
ci: sync-main-to-staging workflow

### DIFF
--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -22,11 +22,15 @@ jobs:
         id: check
         run: |
           git fetch origin staging main
-          if git merge-base --is-ancestor origin/main origin/staging; then
-            echo "Staging already contains all of main — nothing to do."
+          # Use diff rather than ancestry — squash merges break --is-ancestor
+          # even when content is identical. Only skip if no file changes exist.
+          DIFF=$(git diff origin/staging..origin/main --name-only)
+          if [ -z "$DIFF" ]; then
+            echo "Staging content is identical to main — nothing to do."
             echo "in_sync=true" >> "$GITHUB_OUTPUT"
           else
-            echo "main has commits staging does not — backmerge needed."
+            echo "main has changes staging does not:"
+            echo "$DIFF"
             echo "in_sync=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Adds the auto-backmerge workflow to production.

After every push to main, GitHub Actions checks if staging content differs from main (using `git diff --name-only`, not ancestry — squash merges break ancestry checks). If staging is behind, a `sync/main-into-staging-{sha}` branch is created, main is merged in, a PR to staging is opened, and auto-merged if clean. Conflict PRs are left open for manual resolution.

Combined with Dependabot already targeting staging and protect-main.yml blocking non-staging PRs, this fully prevents future staging→main conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)