### PR TITLE
fix: wire guest mode through the frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,31 +14,32 @@ import { GroceryPage } from './pages/GroceryPage'
 
 export function App() {
   const { fetchTasks, fetchMembers } = useStore()
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, isGuest } = useAuthStore()
   const { fetchConfig } = useConfigStore()
+  const canAccessApp = isAuthenticated || isGuest
 
   useEffect(() => {
     fetchConfig()
   }, [fetchConfig])
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (canAccessApp) {
       fetchMembers()
       fetchTasks()
     }
-  }, [isAuthenticated, fetchTasks, fetchMembers])
+  }, [canAccessApp, fetchTasks, fetchMembers])
 
   return (
     <BrowserRouter>
       <Routes>
         <Route
           path="/auth"
-          element={isAuthenticated ? <Navigate to="/" replace /> : <AuthPage />}
+          element={canAccessApp ? <Navigate to="/" replace /> : <AuthPage />}
         />
 
         <Route
           path="/"
-          element={isAuthenticated ? <AppLayout /> : <Navigate to="/auth" replace />}
+          element={canAccessApp ? <AppLayout /> : <Navigate to="/auth" replace />}
         >
           <Route index element={<TasksPage />} />
           <Route path="grocery" element={<GroceryPage />} />
@@ -49,7 +50,7 @@ export function App() {
         <Route path="/join/:token" element={<JoinPage />} />
         <Route path="/refer/:token" element={<ReferralPage />} />
 
-        <Route path="*" element={<Navigate to={isAuthenticated ? '/' : '/auth'} replace />} />
+        <Route path="*" element={<Navigate to={canAccessApp ? '/' : '/auth'} replace />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/components/auth/RegisterFlow.tsx
+++ b/frontend/src/components/auth/RegisterFlow.tsx
@@ -11,8 +11,6 @@ interface Props {
 const ACCENT = '#6366f1'
 const TOTAL_STEPS = 3
 
-const AVATARS: string[] = []
-
 function StepIndicator({ step }: { step: number }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 24 }}>
@@ -43,7 +41,7 @@ export function RegisterFlow({ onSuccess, onBack }: Props) {
   const [username, setUsername] = useState('')
   const [usernameStatus, setUsernameStatus] = useState<'idle' | 'checking' | 'taken' | 'ok'>('idle')
   const [name, setName] = useState('')
-  const [avatar, setAvatar] = useState('')
+  const [avatar] = useState('')
   const [mpin, setMpin] = useState(['', '', '', ''])
   const [confirmMpin, setConfirmMpin] = useState(['', '', '', ''])
   const [loading, setLoading] = useState(false)

--- a/frontend/src/components/layout/AccountMenu.tsx
+++ b/frontend/src/components/layout/AccountMenu.tsx
@@ -6,9 +6,6 @@ import { authApi } from '../../api/auth'
 import { coinsApi, type CoinInfo } from '../../api/coins'
 import { timeAgo } from '../../utils'
 
-// No more emoji avatars
-const AVATARS: string[] = []
-
 const COLORS = ['#6366f1', '#0ea5e9', '#22c55e', '#ef4444', '#a855f7', '#f97316', '#ec4899', '#14b8a6']
 
 type Sheet = 'profile' | 'pin' | 'coins' | null
@@ -35,14 +32,14 @@ export function AccountMenu() {
   const [coinInfo, setCoinInfo] = useState<CoinInfo | null>(null)
 
   const navigate = useNavigate()
-  const { member, clearAuth, updateMember } = useAuthStore()
+  const { member, clearAuth, clearGuest, isGuest, updateMember } = useAuthStore()
 
   useEffect(() => {
-    if (member) {
+    if (member && !isGuest) {
       coinsApi.getMyCoins().then(setCoinInfo).catch(() => {})
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [member?.id])
+  }, [member?.id, isGuest])
 
   const openProfile = () => {
     if (!member) return
@@ -91,7 +88,22 @@ export function AccountMenu() {
     }
   }
 
-  const handleSignOut = () => { setOpen(false); clearAuth(); navigate('/auth') }
+  const leaveGuestMode = (mode: 'login' | 'register') => {
+    setOpen(false)
+    clearGuest()
+    navigate(`/auth?mode=${mode}`)
+  }
+
+  const handleSignOut = () => {
+    setOpen(false)
+    if (isGuest) {
+      clearGuest()
+      navigate('/auth')
+      return
+    }
+    clearAuth()
+    navigate('/auth')
+  }
 
   return (
     <>
@@ -139,12 +151,14 @@ export function AccountMenu() {
                 <p style={{ fontSize: 15, fontWeight: 700, color: '#1c1917', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {member?.name ?? ''}
                 </p>
-                <p style={{ fontSize: 12, color: '#a8a29e', margin: '2px 0 0' }}>@{member?.username}</p>
+                <p style={{ fontSize: 12, color: '#a8a29e', margin: '2px 0 0' }}>
+                  {isGuest ? 'Preview mode' : `@${member?.username}`}
+                </p>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' }}>
-                  {member?.role === 'admin' && (
+                  {!isGuest && member?.role === 'admin' && (
                     <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 7px', borderRadius: 999, background: '#eef2ff', color: ACCENT }}>Admin</span>
                   )}
-                  {coinInfo != null && (
+                  {!isGuest && coinInfo != null && (
                     <button
                       type="button"
                       onClick={(e) => { e.stopPropagation(); setOpen(false); setSheet('coins') }}
@@ -158,13 +172,25 @@ export function AccountMenu() {
             <div style={{ height: 1, background: '#faf7f2' }} />
 
             <div style={{ padding: '6px 0' }}>
-              <>
-                <MenuItem label="Edit profile" onClick={() => { setOpen(false); openProfile() }} />
-                <MenuItem label="Change PIN" onClick={() => { setOpen(false); openPin() }} />
-                <MenuItem label={`${coinInfo?.balance ?? 0} coins`} onClick={() => { setOpen(false); setSheet('coins') }} />
-                <div style={{ height: 1, background: '#faf7f2', margin: '4px 0' }} />
-                <MenuItem label="Sign out" onClick={handleSignOut} danger />
-              </>
+              {isGuest ? (
+                <>
+                  <div style={{ padding: '10px 20px 6px', fontSize: 12, lineHeight: 1.6, color: '#78716c' }}>
+                    Guest tasks are saved only on this device. Create an account when you're ready to keep everything synced.
+                  </div>
+                  <MenuItem label="Create account" onClick={() => leaveGuestMode('register')} />
+                  <MenuItem label="Sign in" onClick={() => leaveGuestMode('login')} />
+                  <div style={{ height: 1, background: '#faf7f2', margin: '4px 0' }} />
+                  <MenuItem label="Exit guest mode" onClick={handleSignOut} danger />
+                </>
+              ) : (
+                <>
+                  <MenuItem label="Edit profile" onClick={() => { setOpen(false); openProfile() }} />
+                  <MenuItem label="Change PIN" onClick={() => { setOpen(false); openPin() }} />
+                  <MenuItem label={`${coinInfo?.balance ?? 0} coins`} onClick={() => { setOpen(false); setSheet('coins') }} />
+                  <div style={{ height: 1, background: '#faf7f2', margin: '4px 0' }} />
+                  <MenuItem label="Sign out" onClick={handleSignOut} danger />
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -2,13 +2,14 @@ import { useEffect, useRef } from 'react'
 import { Outlet, useNavigate } from 'react-router-dom'
 import { BottomNav } from './BottomNav'
 import { AccountMenu } from './AccountMenu'
+import { GuestBanner } from './GuestBanner'
 import { AppLogo } from '../ui/AppLogo'
 import { useAuthStore } from '../../store/authStore'
 import { authApi } from '../../api/auth'
 import { useStore } from '../../store'
 
 export function AppLayout() {
-  const { isAuthenticated, token, setAuth } = useAuthStore()
+  const { isAuthenticated, isGuest, token, setAuth } = useAuthStore()
   const { fetchTasks, fetchMembers, bumpSse } = useStore()
   const navigate = useNavigate()
   const esRef = useRef<EventSource | null>(null)
@@ -68,6 +69,7 @@ export function AppLayout() {
         </div>
         <AccountMenu />
       </div>
+      {isGuest && <GuestBanner />}
       <Outlet />
       <BottomNav />
     </div>

--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -1,4 +1,5 @@
 import { useLocation, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../../store/authStore'
 
 function TasksIcon({ color }: { color: string }) {
   return (
@@ -51,6 +52,8 @@ const MUTED = '#a8a29e'
 export function BottomNav() {
   const location = useLocation()
   const navigate = useNavigate()
+  const { isGuest } = useAuthStore()
+  const navItems = isGuest ? NAV.filter((item) => item.id === '/' || item.id === '/stats') : NAV
 
   return (
     <div style={{
@@ -60,7 +63,7 @@ export function BottomNav() {
       paddingBottom: 'env(safe-area-inset-bottom, 8px)',
       zIndex: 40,
     }}>
-      {NAV.map(({ id, label, Icon }) => {
+      {navItems.map(({ id, label, Icon }) => {
         const isActive = location.pathname === id
         const color = isActive ? ACCENT : MUTED
         return (

--- a/frontend/src/components/layout/GuestBanner.tsx
+++ b/frontend/src/components/layout/GuestBanner.tsx
@@ -1,0 +1,71 @@
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../../store/authStore'
+
+const ACCENT = '#6366f1'
+
+export function GuestBanner() {
+  const navigate = useNavigate()
+  const { clearGuest } = useAuthStore()
+
+  const leaveGuestMode = (mode: 'login' | 'register') => {
+    clearGuest()
+    navigate(`/auth?mode=${mode}`)
+  }
+
+  return (
+    <div style={{
+      padding: '10px 16px',
+      background: '#eef2ff',
+      borderBottom: '1px solid #c7d2fe',
+      display: 'flex',
+      alignItems: 'center',
+      gap: 12,
+      justifyContent: 'space-between',
+      flexWrap: 'wrap',
+    }}>
+      <div>
+        <p style={{ fontSize: 11, fontWeight: 700, color: ACCENT, margin: 0, letterSpacing: 0.7, textTransform: 'uppercase' }}>
+          Guest mode
+        </p>
+        <p style={{ fontSize: 12, color: '#4338ca', margin: '2px 0 0' }}>
+          Preview tasks saved only on this device. No account yet.
+        </p>
+      </div>
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          type="button"
+          onClick={() => leaveGuestMode('login')}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid #c7d2fe',
+            background: 'white',
+            color: ACCENT,
+            fontSize: 12,
+            fontWeight: 700,
+            cursor: 'pointer',
+          }}
+        >
+          Sign in
+        </button>
+        <button
+          type="button"
+          onClick={() => leaveGuestMode('register')}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: 'none',
+            background: ACCENT,
+            color: 'white',
+            fontSize: 12,
+            fontWeight: 700,
+            cursor: 'pointer',
+          }}
+        >
+          Create account
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/members/HouseholdPanel.tsx
+++ b/frontend/src/components/members/HouseholdPanel.tsx
@@ -23,7 +23,7 @@ export function HouseholdPanel() {
   const [household, setHousehold] = useState<HouseholdData>(_cache?.household ?? null)
   const [loadingHousehold, setLoadingHousehold] = useState(_cache === null)
 
-  const [createKind, setCreateKind] = useState<'home' | 'group'>('home')
+  const [createKind] = useState<'home' | 'group'>('home')
   const [createName, setCreateName] = useState('')
   const [createBusy, setCreateBusy] = useState(false)
 

--- a/frontend/src/components/tasks/AddGrocerySheet.tsx
+++ b/frontend/src/components/tasks/AddGrocerySheet.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { type Member, type CreateGroceryPayload } from '../../types'
 import { useStore } from '../../store'
-import { useAuthStore } from '../../store/authStore'
 
 interface Props {
   members: Member[]
@@ -11,7 +10,6 @@ interface Props {
 
 export function AddGrocerySheet({ members, onClose, onAdded }: Props) {
   const { createGrocery } = useStore()
-  const { member } = useAuthStore()
 
   const [form, setForm] = useState<CreateGroceryPayload>({
     title: '', quantity: '', notes: '',

--- a/frontend/src/components/tasks/AddTaskSheet.tsx
+++ b/frontend/src/components/tasks/AddTaskSheet.tsx
@@ -66,7 +66,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 export function AddTaskSheet({ members, onClose, onAdded, hiddenCategories, defaultCategory }: Props) {
   const { createTask } = useStore()
-  const { member } = useAuthStore()
+  const { member, isGuest } = useAuthStore()
 
   const defaultAssignee = members[0]?.id ?? ''
   const initialCategory: Category = defaultCategory ?? (hiddenCategories?.includes('chore') ? (Object.keys(CATEGORY_CONFIG) as Category[]).find(c => !hiddenCategories.includes(c))! : 'chore')
@@ -75,7 +75,7 @@ export function AddTaskSheet({ members, onClose, onAdded, hiddenCategories, defa
     title: '', notes: '', category: initialCategory,
     priority: CATEGORY_CONFIG[initialCategory].defaultPriority,
     assignee_id: defaultAssignee,
-    household_id: member?.household_id ?? '',
+    household_id: isGuest ? 'guest' : member?.household_id ?? '',
   })
   const [saving, setSaving] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)

--- a/frontend/src/components/tasks/TaskDrawer.tsx
+++ b/frontend/src/components/tasks/TaskDrawer.tsx
@@ -24,16 +24,20 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [activities, setActivities] = useState<Activity[]>([])
-  const { addComment, deleteTask } = useStore()
-  const { member: authMember } = useAuthStore()
+  const { addComment, deleteTask, updateTask } = useStore()
+  const { member: authMember, isGuest } = useAuthStore()
   const me = members.find((m) => m.id === authMember?.id) ?? members[0]
 
   const fetchActivities = useCallback(async () => {
+    if (isGuest) {
+      setActivities([])
+      return
+    }
     try {
       const data = await tasksApi.getActivity(current.id)
       setActivities(data)
     } catch {}
-  }, [current.id])
+  }, [current.id, isGuest])
 
   useEffect(() => { fetchActivities() }, [fetchActivities])
 
@@ -42,7 +46,7 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
     setSaving(true)
     setSaveError(null)
     try {
-      const updated = await tasksApi.update(current.id, payload)
+      const updated = await updateTask(current.id, payload)
       setCurrent(updated)
       onUpdated(updated)
       fetchActivities()
@@ -61,8 +65,8 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
     setSendingComment(true)
     try {
       await addComment(current.id, body)
-      const fresh = await tasksApi.get(current.id)
-      setCurrent(fresh)
+      const fresh = useStore.getState().tasks.find((taskItem) => taskItem.id === current.id)
+      if (fresh) setCurrent(fresh)
     } catch {
       setComment(body)
     } finally {

--- a/frontend/src/components/ui/GuestOnlyNotice.tsx
+++ b/frontend/src/components/ui/GuestOnlyNotice.tsx
@@ -1,0 +1,96 @@
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../../store/authStore'
+
+interface Props {
+  title: string
+  description: string
+}
+
+const ACCENT = '#6366f1'
+
+export function GuestOnlyNotice({ title, description }: Props) {
+  const navigate = useNavigate()
+  const { clearGuest } = useAuthStore()
+
+  const leaveGuestMode = (mode: 'login' | 'register') => {
+    clearGuest()
+    navigate(`/auth?mode=${mode}`)
+  }
+
+  return (
+    <div style={{ padding: '56px 20px 120px', display: 'flex', justifyContent: 'center' }}>
+      <div style={{
+        width: '100%',
+        maxWidth: 360,
+        background: 'white',
+        border: '1px solid #ede8e1',
+        borderRadius: 16,
+        padding: '28px 24px',
+        textAlign: 'center',
+      }}>
+        <div style={{
+          width: 60,
+          height: 60,
+          borderRadius: 18,
+          background: '#eef2ff',
+          color: ACCENT,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 24,
+          fontWeight: 800,
+          margin: '0 auto 18px',
+        }}>
+          G
+        </div>
+
+        <p style={{ fontSize: 11, fontWeight: 700, color: ACCENT, letterSpacing: 0.8, textTransform: 'uppercase', margin: '0 0 10px' }}>
+          Guest mode
+        </p>
+        <h2 style={{ fontSize: 22, fontWeight: 700, color: '#1c1917', margin: '0 0 8px', fontFamily: 'Fraunces, serif' }}>
+          {title}
+        </h2>
+        <p style={{ fontSize: 13, color: '#78716c', lineHeight: 1.6, margin: '0 0 22px' }}>
+          {description}
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <button
+            type="button"
+            onClick={() => leaveGuestMode('register')}
+            style={{
+              width: '100%',
+              padding: '12px 0',
+              borderRadius: 10,
+              border: 'none',
+              background: ACCENT,
+              color: 'white',
+              fontSize: 14,
+              fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >
+            Create account
+          </button>
+          <button
+            type="button"
+            onClick={() => leaveGuestMode('login')}
+            style={{
+              width: '100%',
+              padding: '12px 0',
+              borderRadius: 10,
+              border: '1px solid #ede8e1',
+              background: 'white',
+              color: '#78716c',
+              fontSize: 14,
+              fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >
+            Sign in
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useAuthStore } from '../store/authStore'
 import { householdsApi } from '../api/households'
 import { AppLogo } from '../components/ui/AppLogo'
@@ -16,8 +16,18 @@ const FEATURES = [
 ]
 
 export function AuthPage() {
-  const [mode, setMode] = useState<Mode>('landing')
-  const { setAuth } = useAuthStore()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { setAuth, setGuest } = useAuthStore()
+  const requestedMode = searchParams.get('mode')
+  const mode: Mode = requestedMode === 'login' || requestedMode === 'register' ? requestedMode : 'landing'
+
+  const goToMode = (nextMode: Mode) => {
+    if (nextMode === 'landing') {
+      setSearchParams({})
+      return
+    }
+    setSearchParams({ mode: nextMode })
+  }
 
   const handleSuccess = async (token: string, member: Member) => {
     const pendingJoin = localStorage.getItem('hj_pending_join')
@@ -38,8 +48,8 @@ export function AuthPage() {
       <AuthShell>
         <LoginFlow 
           onSuccess={handleSuccess} 
-          onBack={() => setMode('landing')} 
-          onGoRegister={() => setMode('register')}
+          onBack={() => goToMode('landing')}
+          onGoRegister={() => goToMode('register')}
         />
       </AuthShell>
     )
@@ -48,7 +58,7 @@ export function AuthPage() {
   if (mode === 'register') {
     return (
       <AuthShell>
-        <RegisterFlow onSuccess={handleSuccess} onBack={() => setMode('landing')} />
+        <RegisterFlow onSuccess={handleSuccess} onBack={() => goToMode('landing')} />
       </AuthShell>
     )
   }
@@ -122,7 +132,7 @@ export function AuthPage() {
       <div className="hj-fade-up-3" style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%', maxWidth: 360 }}>
         <button
           className="hj-btn-primary"
-          onClick={() => setMode('register')}
+          onClick={() => goToMode('register')}
           style={{
             width: '100%', padding: '15px 0', borderRadius: 14, border: 'none',
             background: ACCENT, color: 'white', fontSize: 15, fontWeight: 700,
@@ -134,7 +144,7 @@ export function AuthPage() {
         </button>
         <button
           className="hj-btn-secondary"
-          onClick={() => setMode('login')}
+          onClick={() => goToMode('login')}
           style={{
             width: '100%', padding: '15px 0', borderRadius: 14,
             border: '1.5px solid #e0deff', background: 'white',
@@ -144,6 +154,24 @@ export function AuthPage() {
           }}
         >
           Sign in
+        </button>
+        <button
+          type="button"
+          onClick={setGuest}
+          style={{
+            width: '100%',
+            padding: '13px 0',
+            borderRadius: 14,
+            border: '1px dashed #c7d2fe',
+            background: '#eef2ff',
+            color: ACCENT,
+            fontSize: 14,
+            fontWeight: 700,
+            letterSpacing: -0.1,
+            cursor: 'pointer',
+          }}
+        >
+          Try as guest
         </button>
       </div>
 

--- a/frontend/src/pages/GroceryPage.tsx
+++ b/frontend/src/pages/GroceryPage.tsx
@@ -1,14 +1,15 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useAuthStore } from '../store/authStore'
 import { useStore } from '../store'
 import { Spinner } from '../components/ui/Spinner'
+import { GuestOnlyNotice } from '../components/ui/GuestOnlyNotice'
 import { AddGrocerySheet } from '../components/tasks/AddGrocerySheet'
 import type { Grocery } from '../types'
 
 const ACCENT = '#6366f1'
 
 export function GroceryPage() {
-  const { member } = useAuthStore()
+  const { isGuest } = useAuthStore()
   const { groceries, fetchGroceries, toggleGrocery, deleteGrocery, updateGrocery, sseVersion, members } = useStore()
 
   const [loading, setLoading] = useState(groceries.length === 0)
@@ -18,16 +19,20 @@ export function GroceryPage() {
   const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set([todayKey]))
   const [showAdd, setShowAdd] = useState(false)
 
-  const load = async () => {
+  const load = useCallback(async () => {
     try {
       await fetchGroceries()
     } finally {
       setLoading(false)
     }
-  }
+  }, [fetchGroceries])
 
-  useEffect(() => { load() }, [])
-  useEffect(() => { if (sseVersion > 0) load() }, [sseVersion])
+  useEffect(() => {
+    if (!isGuest) load()
+  }, [isGuest, load])
+  useEffect(() => {
+    if (!isGuest && sseVersion > 0) load()
+  }, [isGuest, load, sseVersion])
 
   const active = groceries.filter(g => !g.done)
   const done = groceries.filter(g => g.done).sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
@@ -39,6 +44,25 @@ export function GroceryPage() {
   }
 
   const handleClearDone = () => setShowDone(false)
+
+  if (isGuest) {
+    return (
+      <>
+        <div style={{
+          background: 'white', padding: '10px 16px',
+          borderBottom: '1px solid #ede8e1',
+          position: 'sticky', top: 57, zIndex: 49,
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        }}>
+          <h2 style={{ fontSize: 13, fontWeight: 600, color: '#78716c', margin: 0, letterSpacing: 0.2 }}>Grocery</h2>
+        </div>
+        <GuestOnlyNotice
+          title="Grocery lists unlock with an account"
+          description="Guest mode is a lightweight task preview. Create an account to share groceries, sync across devices, and collaborate with your household."
+        />
+      </>
+    )
+  }
 
   if (loading) return <Spinner />
 

--- a/frontend/src/pages/MembersPage.tsx
+++ b/frontend/src/pages/MembersPage.tsx
@@ -2,9 +2,10 @@ import { useStore } from '../store'
 import { useAuthStore } from '../store/authStore'
 import { MembersScreen } from '../components/members/MembersScreen'
 import { HouseholdPanel } from '../components/members/HouseholdPanel'
+import { GuestOnlyNotice } from '../components/ui/GuestOnlyNotice'
 export function MembersPage() {
   const { tasks, members } = useStore()
-  const { member } = useAuthStore()
+  const { member, isGuest } = useAuthStore()
 
   return (
     <>
@@ -14,14 +15,23 @@ export function MembersPage() {
       }}>
         <h2 style={{ fontSize: 13, fontWeight: 600, color: '#78716c', margin: 0, letterSpacing: 0.2 }}>Household</h2>
       </div>
-      <HouseholdPanel />
-      {!!member?.household_id && (
+      {isGuest ? (
+        <GuestOnlyNotice
+          title="Households need a real account"
+          description="Guest mode lets you preview task management locally. Create an account to invite people, join a household, and sync updates in real time."
+        />
+      ) : (
+        <>
+          <HouseholdPanel />
+          {!!member?.household_id && (
         <MembersScreen
           tasks={tasks}
           members={members}
           currentMember={member}
           isAdmin={member.role === 'admin'}
         />
+          )}
+        </>
       )}
     </>
   )

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -5,9 +5,9 @@ import { StatsScreen } from '../components/stats/StatsScreen'
 
 export function StatsPage() {
   const { tasks, members } = useStore()
-  const { member } = useAuthStore()
+  const { member, isGuest } = useAuthStore()
 
-  if (member && !member.household_id) {
+  if (!isGuest && member && !member.household_id) {
     return <Navigate to="/household" replace />
   }
 

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -15,7 +15,7 @@ const ACCENT = '#6366f1'
 
 export function TasksPage() {
   const { tasks, members, loading, fetchTasks, toggleTask, deleteTask } = useStore()
-  const { member } = useAuthStore()
+  const { member, isGuest } = useAuthStore()
   const [catTab, setCatTab] = useState<Category | 'all'>('all')
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('open')
   const [sortBy, setSortBy] = useState<SortBy>('priority')
@@ -48,7 +48,7 @@ export function TasksPage() {
     }
   }, [toggleTask, undoTask, undoTimer])
 
-  if (member && !member.household_id) {
+  if (!isGuest && member && !member.household_id) {
     return <Navigate to="/household" replace />
   }
 
@@ -231,7 +231,7 @@ export function TasksPage() {
             </div>
             <h2 style={{ fontSize: 18, fontWeight: 700, color: '#1c1917', margin: '0 0 6px' }}>No tasks yet</h2>
             <p style={{ fontSize: 13, color: '#a8a29e', margin: '0 0 24px', lineHeight: 1.6, maxWidth: 240 }}>
-              Add your household's first task to get started.
+              {isGuest ? 'Add a few preview tasks to try the app locally.' : 'Add your household\'s first task to get started.'}
             </p>
             <button
               onClick={() => setShowAdd(true)}

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,9 +1,10 @@
 import { create } from 'zustand'
 import type { Member } from '../types'
+import { GUEST_MEMBER, GUEST_STORAGE_KEY } from './guest'
 
 // Initialize from localStorage at module load (before first React render — no auth flash)
 const initialToken = localStorage.getItem('hj_token')
-const initialMember: Member | null = (() => {
+const storedMember: Member | null = (() => {
   try {
     const raw = localStorage.getItem('hj_member')
     return raw ? (JSON.parse(raw) as Member) : null
@@ -11,39 +12,67 @@ const initialMember: Member | null = (() => {
     return null
   }
 })()
+const initialIsGuest = !initialToken && localStorage.getItem(GUEST_STORAGE_KEY) === 'true'
+const initialMember = initialIsGuest ? GUEST_MEMBER : storedMember
 
 interface AuthStore {
   token: string | null
   member: Member | null
   isAuthenticated: boolean
+  isGuest: boolean
 
   setAuth: (token: string, member: Member) => void
+  setGuest: () => void
   updateMember: (member: Member) => void
   clearAuth: () => void
+  clearGuest: () => void
 }
 
 export const useAuthStore = create<AuthStore>(() => ({
   token: initialToken,
   member: initialMember,
-  isAuthenticated: !!(initialToken && initialMember),
+  isAuthenticated: !!(initialToken && initialMember && !initialIsGuest),
+  isGuest: initialIsGuest,
 
   setAuth: (token, member) => {
+    localStorage.removeItem(GUEST_STORAGE_KEY)
     localStorage.setItem('hj_token', token)
     localStorage.setItem('hj_member', JSON.stringify(member))
-    useAuthStore.setState({ token, member, isAuthenticated: true })
+    useAuthStore.setState({ token, member, isAuthenticated: true, isGuest: false })
+  },
+
+  setGuest: () => {
+    localStorage.removeItem('hj_token')
+    localStorage.removeItem('hj_member')
+    localStorage.setItem(GUEST_STORAGE_KEY, 'true')
+    useAuthStore.setState({
+      token: null,
+      member: GUEST_MEMBER,
+      isAuthenticated: false,
+      isGuest: true,
+    })
   },
 
   updateMember: (member) => {
-    localStorage.setItem('hj_member', JSON.stringify(member))
     useAuthStore.setState((state) => ({
+      token: state.token,
       member,
-      isAuthenticated: !!(state.token && member),
+      isAuthenticated: !!(state.token && member) && !state.isGuest,
+      isGuest: state.isGuest,
     }))
+    if (!useAuthStore.getState().isGuest) {
+      localStorage.setItem('hj_member', JSON.stringify(member))
+    }
   },
 
   clearAuth: () => {
     localStorage.removeItem('hj_token')
     localStorage.removeItem('hj_member')
-    useAuthStore.setState({ token: null, member: null, isAuthenticated: false })
+    useAuthStore.setState({ token: null, member: null, isAuthenticated: false, isGuest: false })
+  },
+
+  clearGuest: () => {
+    localStorage.removeItem(GUEST_STORAGE_KEY)
+    useAuthStore.setState({ token: null, member: null, isAuthenticated: false, isGuest: false })
   },
 }))

--- a/frontend/src/store/guest.ts
+++ b/frontend/src/store/guest.ts
@@ -1,10 +1,13 @@
 import type { Task, Member, Comment } from '../types'
 
+export const GUEST_STORAGE_KEY = 'hj_guest'
+
 export const GUEST_MEMBER: Member = {
   id: 'guest',
   name: 'Guest',
   avatar: 'G',
-  color: '#f97316',
+  color: '#6366f1',
+  username: 'guest',
   created_at: new Date().toISOString(),
 }
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,8 +1,44 @@
 import { create } from 'zustand'
-import type { Task, Member, TaskFilter, CreateTaskPayload, Grocery, CreateGroceryPayload, UpdateGroceryPayload } from '../types'
+import type { Task, Member, TaskFilter, CreateTaskPayload, Grocery, CreateGroceryPayload, UpdateGroceryPayload, UpdateTaskPayload } from '../types'
 import { tasksApi } from '../api/tasks'
 import { membersApi } from '../api/members'
 import { groceriesApi } from '../api/groceries'
+import { useAuthStore } from './authStore'
+import { GUEST_MEMBER, loadGuestTasks, makeGuestComment, saveGuestTasks } from './guest'
+
+function hydrateGuestTask(task: Task): Task {
+  return {
+    ...task,
+    assignee: task.assignee_id === GUEST_MEMBER.id ? GUEST_MEMBER : undefined,
+  }
+}
+
+function hydrateGuestTasks(tasks: Task[]): Task[] {
+  return tasks.map(hydrateGuestTask)
+}
+
+function applyTaskPatch(task: Task, payload: UpdateTaskPayload, members: Member[]): Task {
+  const now = new Date().toISOString()
+  const nextDone = payload.done ?? task.done
+  const nextAssigneeID = payload.assignee_id !== undefined ? payload.assignee_id : task.assignee_id
+  const nextDueAt = payload.clear_due_at ? undefined : payload.due_at !== undefined ? payload.due_at : task.due_at
+  const nextQuantity = payload.quantity !== undefined ? payload.quantity : task.quantity
+
+  return {
+    ...task,
+    title: payload.title ?? task.title,
+    notes: payload.notes ?? task.notes,
+    category: payload.category ?? task.category,
+    priority: payload.priority ?? task.priority,
+    assignee_id: nextAssigneeID,
+    assignee: members.find((member) => member.id === nextAssigneeID) ?? task.assignee,
+    due_at: nextDueAt,
+    quantity: nextQuantity,
+    done: nextDone,
+    done_at: nextDone ? task.done_at ?? now : undefined,
+    updated_at: now,
+  }
+}
 
 interface AppStore {
   tasks: Task[]
@@ -19,6 +55,7 @@ interface AppStore {
   fetchGroceries: () => Promise<void>
   fetchMembers: () => Promise<void>
   createTask: (payload: CreateTaskPayload) => Promise<void>
+  updateTask: (id: string, payload: UpdateTaskPayload) => Promise<Task>
   toggleTask: (id: string, done: boolean) => Promise<void>
   deleteTask: (id: string) => Promise<void>
   addComment: (taskId: string, body: string) => Promise<void>
@@ -42,6 +79,16 @@ export const useStore = create<AppStore>((set, get) => ({
   bumpSse: () => set((s) => ({ sseVersion: s.sseVersion + 1 })),
 
   fetchTasks: async () => {
+    if (useAuthStore.getState().isGuest) {
+      set({
+        tasks: hydrateGuestTasks(loadGuestTasks()),
+        members: [GUEST_MEMBER],
+        loading: false,
+        error: null,
+      })
+      return
+    }
+
     const isInitial = get().tasks.length === 0
     if (isInitial) set({ loading: true, error: null })
     try {
@@ -57,6 +104,11 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   fetchGroceries: async () => {
+    if (useAuthStore.getState().isGuest) {
+      set({ groceries: [] })
+      return
+    }
+
     try {
       const groceries = await groceriesApi.list()
       if (JSON.stringify(groceries) !== JSON.stringify(get().groceries)) {
@@ -68,6 +120,11 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   fetchMembers: async () => {
+    if (useAuthStore.getState().isGuest) {
+      set({ members: [GUEST_MEMBER] })
+      return
+    }
+
     try {
       const members = await membersApi.list()
       if (JSON.stringify(members) !== JSON.stringify(get().members)) {
@@ -79,25 +136,73 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   createTask: async (payload) => {
+    if (useAuthStore.getState().isGuest) {
+      const now = new Date().toISOString()
+      const task = hydrateGuestTask({
+        id: crypto.randomUUID(),
+        title: payload.title.trim(),
+        notes: payload.notes.trim(),
+        category: payload.category,
+        priority: payload.priority,
+        assignee_id: payload.assignee_id || GUEST_MEMBER.id,
+        done: false,
+        due_at: payload.due_at,
+        quantity: payload.quantity,
+        created_at: now,
+        updated_at: now,
+        comments: [],
+      })
+      const tasks = [task, ...get().tasks]
+      saveGuestTasks(tasks)
+      set({ tasks, members: [GUEST_MEMBER] })
+      return
+    }
+
     const task = await tasksApi.create(payload)
     set((s) => ({ tasks: [task, ...s.tasks] }))
   },
 
-  toggleTask: async (id, done) => {
+  updateTask: async (id, payload) => {
     const previous = get().tasks.find((t) => t.id === id)
-    set((s) => ({ tasks: s.tasks.map((t) => t.id === id ? { ...t, done } : t) }))
+    if (!previous) throw new Error('Task not found')
+
+    const members = get().members.length > 0 ? get().members : [GUEST_MEMBER]
+    const optimistic = applyTaskPatch(previous, payload, members)
+
+    if (useAuthStore.getState().isGuest) {
+      const tasks = get().tasks.map((task) => task.id === id ? optimistic : task)
+      saveGuestTasks(tasks)
+      set({ tasks, members: [GUEST_MEMBER] })
+      return optimistic
+    }
+
+    set((state) => ({ tasks: state.tasks.map((task) => task.id === id ? optimistic : task) }))
     try {
-      const updated = await tasksApi.update(id, { done })
-      set((s) => ({ tasks: s.tasks.map((t) => t.id === id ? updated : t) }))
+      const updated = await tasksApi.update(id, payload)
+      set((state) => ({ tasks: state.tasks.map((task) => task.id === id ? updated : task) }))
+      return updated
     } catch {
       if (previous) {
-        set((s) => ({ tasks: s.tasks.map((t) => t.id === id ? previous : t) }))
+        set((state) => ({ tasks: state.tasks.map((task) => task.id === id ? previous : task) }))
       }
+      throw new Error('Failed to update task')
     }
+  },
+
+  toggleTask: async (id, done) => {
+    await get().updateTask(id, { done })
   },
 
   deleteTask: async (id) => {
     const previous = get().tasks.find((t) => t.id === id)
+
+    if (useAuthStore.getState().isGuest) {
+      const tasks = get().tasks.filter((task) => task.id !== id)
+      saveGuestTasks(tasks)
+      set({ tasks })
+      return
+    }
+
     set((s) => ({ tasks: s.tasks.filter((t) => t.id !== id) }))
     try {
       await tasksApi.remove(id)
@@ -108,6 +213,18 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   addComment: async (taskId, body) => {
+    if (useAuthStore.getState().isGuest) {
+      const comment = makeGuestComment(taskId, body)
+      const tasks = get().tasks.map((task) =>
+        task.id === taskId
+          ? { ...task, comments: [...(task.comments ?? []), comment], updated_at: comment.created_at }
+          : task
+      )
+      saveGuestTasks(tasks)
+      set({ tasks })
+      return
+    }
+
     const comment = await tasksApi.addComment(taskId, body)
     set((s) => ({
       tasks: s.tasks.map((t) =>
@@ -117,11 +234,19 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   createGrocery: async (payload) => {
+    if (useAuthStore.getState().isGuest) {
+      throw new Error('Grocery list is unavailable in guest mode')
+    }
+
     const g = await groceriesApi.create(payload)
     set((s) => ({ groceries: [g, ...s.groceries] }))
   },
 
   toggleGrocery: async (id, done) => {
+    if (useAuthStore.getState().isGuest) {
+      throw new Error('Grocery list is unavailable in guest mode')
+    }
+
     const previous = get().groceries.find((g) => g.id === id)
     set((s) => ({ groceries: s.groceries.map((g) => g.id === id ? { ...g, done } : g) }))
     try {
@@ -135,11 +260,19 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   updateGrocery: async (id, payload) => {
+    if (useAuthStore.getState().isGuest) {
+      throw new Error('Grocery list is unavailable in guest mode')
+    }
+
     const updated = await groceriesApi.update(id, payload)
     set((s) => ({ groceries: s.groceries.map((g) => g.id === id ? updated : g) }))
   },
 
   deleteGrocery: async (id) => {
+    if (useAuthStore.getState().isGuest) {
+      throw new Error('Grocery list is unavailable in guest mode')
+    }
+
     const previous = get().groceries.find((g) => g.id === id)
     set((s) => ({ groceries: s.groceries.filter((g) => g.id !== id) }))
     try {


### PR DESCRIPTION
## Summary
- add a real guest-mode auth state and public "Try as guest" entry path
- route guest users through localStorage-backed task flows instead of API calls
- show guest-safe UI for unsupported sections like grocery and household

## Testing
- npm run build
- npm run lint
- pre-commit frontend build + lint
- pre-push backend service tests with coverage (80.4%)

Closes #117
Closes #118