### PR TITLE
fix: refresh JWT after joining household via invite link

### DIFF
--- a/frontend/src/pages/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { householdsApi, type Household } from '../api/households'
+import { authApi } from '../api/auth'
 import { useAuthStore } from '../store/authStore'
 import { Spinner } from '../components/ui/Spinner'
 
@@ -9,7 +10,7 @@ const ACCENT = '#6366f1'
 export function JoinPage() {
   const { token } = useParams<{ token: string }>()
   const navigate = useNavigate()
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, setAuth } = useAuthStore()
 
   const [household, setHousehold] = useState<Household | null>(null)
   const [error, setError] = useState('')
@@ -31,7 +32,11 @@ export function JoinPage() {
     if (!loading && household && isAuthenticated) {
       setJoining(true)
       householdsApi.joinByInviteToken(token!)
-        .then(() => navigate('/household', { replace: true }))
+        .then(() => authApi.refresh())
+        .then(({ token: newToken, member }) => {
+          setAuth(newToken, member)
+          navigate('/household', { replace: true })
+        })
         .catch((err: unknown) => {
           setJoining(false)
           setError((err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Failed to join household.')


### PR DESCRIPTION
## What
After a user joins a household via invite link, call `/auth/refresh` to get a new JWT with `household_id` embedded before navigating.

## Why
`joinByInviteToken` adds the user to the household in the DB but the existing JWT still has an empty `household_id`. All subsequent household-scoped API calls silently fail until the user logs out and back in.

## Checklist
- [x] `make up` — runs locally
- [x] `npm run build` passes