### PR TITLE
feat: desktop layout foundation — sidebar nav at ≥900px

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import { useStore } from './store'
 import { useAuthStore } from './store/authStore'
 import { useConfigStore } from './store/configStore'
 import { AppLayout } from './components/layout/AppLayout'
+import { DesktopLayout } from './components/layout/desktop/DesktopLayout'
+import { useBreakpoint } from './hooks/useBreakpoint'
 import { TasksPage } from './pages/TasksPage'
 import { StatsPage } from './pages/StatsPage'
 import { MembersPage } from './pages/MembersPage'
@@ -17,6 +19,8 @@ export function App() {
   const { isAuthenticated, isGuest } = useAuthStore()
   const { fetchConfig } = useConfigStore()
   const canAccessApp = isAuthenticated || isGuest
+  const isDesktop = useBreakpoint()
+  const Layout = isDesktop ? DesktopLayout : AppLayout
 
   useEffect(() => {
     fetchConfig()
@@ -39,7 +43,7 @@ export function App() {
 
         <Route
           path="/"
-          element={canAccessApp ? <AppLayout /> : <Navigate to="/auth" replace />}
+          element={canAccessApp ? <Layout /> : <Navigate to="/auth" replace />}
         >
           <Route index element={<TasksPage />} />
           <Route path="grocery" element={<GroceryPage />} />

--- a/frontend/src/components/layout/desktop/DesktopLayout.tsx
+++ b/frontend/src/components/layout/desktop/DesktopLayout.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import { Outlet, useNavigate } from 'react-router-dom'
+import { SideNav } from './SideNav'
+import { AccountMenu } from '../AccountMenu'
+import { GuestBanner } from '../GuestBanner'
+import { AppLogo } from '../../ui/AppLogo'
+import { useAuthStore } from '../../../store/authStore'
+import { authApi } from '../../../api/auth'
+import { useStore } from '../../../store'
+import { TOP_BAR_HEIGHT } from '../../../constants/layout'
+
+export function DesktopLayout() {
+  const { isAuthenticated, isGuest, token, setAuth } = useAuthStore()
+  const { fetchTasks, fetchMembers, bumpSse } = useStore()
+  const navigate = useNavigate()
+  const esRef = useRef<EventSource | null>(null)
+
+  useEffect(() => {
+    if (!isAuthenticated || !token) return
+
+    fetchTasks()
+    fetchMembers()
+
+    const apiBase = (import.meta.env.VITE_API_URL as string | undefined) ?? '/api/v1'
+    const es = new EventSource(`${apiBase}/events?token=${encodeURIComponent(token)}`)
+    esRef.current = es
+
+    es.onmessage = async () => {
+      bumpSse()
+      await fetchMembers()
+      fetchTasks()
+
+      const currentMember = useAuthStore.getState().member
+      if (currentMember?.household_id) {
+        const stillPresent = useStore.getState().members.some((m) => m.id === currentMember.id)
+        if (!stillPresent) {
+          try {
+            const { token: newToken, member: fresh } = await authApi.refresh()
+            setAuth(newToken, fresh)
+          } catch {}
+          navigate('/household')
+        }
+      }
+    }
+
+    return () => {
+      es.close()
+      esRef.current = null
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, token])
+
+  return (
+    <div style={{ minHeight: '100vh', background: '#faf7f2', display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{
+        background: 'white',
+        borderBottom: '1px solid #ede8e1',
+        position: 'sticky',
+        top: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0 24px',
+        height: TOP_BAR_HEIGHT,
+        flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <AppLogo size={30} />
+          <span style={{ fontSize: 18, fontWeight: 700, color: '#1c1917', letterSpacing: -0.3 }}>HomeJira</span>
+        </div>
+        <AccountMenu />
+      </div>
+
+      {/* Body: sidebar + content */}
+      <div style={{ display: 'flex', flex: 1 }}>
+        <SideNav />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+          {isGuest && <GuestBanner />}
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/desktop/SideNav.tsx
+++ b/frontend/src/components/layout/desktop/SideNav.tsx
@@ -1,0 +1,103 @@
+import { useLocation, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../../../store/authStore'
+import { SIDE_NAV_WIDTH, TOP_BAR_HEIGHT } from '../../../constants/layout'
+
+const ACCENT = '#6366f1'
+const MUTED = '#78716c'
+
+function TasksIcon({ color }: { color: string }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 11l3 3L22 4" />
+      <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
+    </svg>
+  )
+}
+
+function GroceryIcon({ color }: { color: string }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <path d="M16 10a4 4 0 01-8 0" />
+    </svg>
+  )
+}
+
+function StatsIcon({ color }: { color: string }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="18" y="3" width="4" height="18" rx="1" />
+      <rect x="10" y="8" width="4" height="13" rx="1" />
+      <rect x="2" y="13" width="4" height="8" rx="1" />
+    </svg>
+  )
+}
+
+function HouseholdIcon({ color }: { color: string }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+      <polyline points="9,22 9,12 15,12 15,22" />
+    </svg>
+  )
+}
+
+const NAV = [
+  { id: '/', label: 'Tasks', Icon: TasksIcon },
+  { id: '/grocery', label: 'Grocery', Icon: GroceryIcon },
+  { id: '/stats', label: 'Stats', Icon: StatsIcon },
+  { id: '/household', label: 'Household', Icon: HouseholdIcon },
+]
+
+export function SideNav() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { isGuest } = useAuthStore()
+  const navItems = isGuest ? NAV.filter((item) => item.id === '/' || item.id === '/stats') : NAV
+
+  return (
+    <div style={{
+      width: SIDE_NAV_WIDTH,
+      flexShrink: 0,
+      background: 'white',
+      borderRight: '1px solid #ede8e1',
+      display: 'flex',
+      flexDirection: 'column',
+      position: 'sticky',
+      top: TOP_BAR_HEIGHT,
+      height: `calc(100vh - ${TOP_BAR_HEIGHT}px)`,
+      overflowY: 'auto',
+      paddingTop: 12,
+    }}>
+      {navItems.map(({ id, label, Icon }) => {
+        const isActive = location.pathname === id
+        return (
+          <button
+            key={id}
+            onClick={() => navigate(id)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              margin: '2px 10px',
+              padding: '9px 12px',
+              borderRadius: 8,
+              border: 'none',
+              background: isActive ? '#eef2ff' : 'transparent',
+              color: isActive ? ACCENT : MUTED,
+              fontSize: 14,
+              fontWeight: isActive ? 700 : 500,
+              cursor: 'pointer',
+              textAlign: 'left',
+              transition: 'background 0.15s, color 0.15s',
+            }}
+          >
+            <Icon color={isActive ? ACCENT : MUTED} />
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/constants/layout.ts
+++ b/frontend/src/constants/layout.ts
@@ -1,0 +1,3 @@
+export const TOP_BAR_HEIGHT = 57
+export const SIDE_NAV_WIDTH = 220
+export const DESKTOP_BREAKPOINT = 900

--- a/frontend/src/hooks/useBreakpoint.ts
+++ b/frontend/src/hooks/useBreakpoint.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react'
+import { DESKTOP_BREAKPOINT } from '../constants/layout'
+
+export function useBreakpoint(minWidth = DESKTOP_BREAKPOINT): boolean {
+  const [isDesktop, setIsDesktop] = useState(
+    () => window.matchMedia(`(min-width: ${minWidth}px)`).matches
+  )
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(min-width: ${minWidth}px)`)
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [minWidth])
+
+  return isDesktop
+}


### PR DESCRIPTION
## What
Parallel desktop shell that activates at 900px viewport width. Mobile layout is completely untouched.

## Changes
- `useBreakpoint` hook — synchronous `matchMedia`, no flash/re-mount on first render
- `constants/layout.ts` — shared `TOP_BAR_HEIGHT`, `SIDE_NAV_WIDTH`, `DESKTOP_BREAKPOINT`
- `SideNav` — vertical left nav, same routes and guest filtering as `BottomNav`
- `DesktopLayout` — full-width shell: sticky top bar + sidebar column + content pane with SSE
- `App.tsx` — one conditional: `isDesktop ? DesktopLayout : AppLayout`

## Checklist
- [x] `make up` — runs locally
- [x] `npm run build` passes
- [x] Mobile layout unchanged (AppLayout/BottomNav not modified)