### PR TITLE
feat(desktop): Tasks page — two-column list + inline detail panel

### DIFF
--- a/frontend/src/components/layout/desktop/DesktopTaskDetail.tsx
+++ b/frontend/src/components/layout/desktop/DesktopTaskDetail.tsx
@@ -1,0 +1,317 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Avatar } from '../../ui/Avatar'
+import { CATEGORIES, PRIORITIES, type Task, type Member, type UpdateTaskPayload, type Category, type Priority, type Activity } from '../../../types'
+import { tasksApi } from '../../../api/tasks'
+import { timeAgo, toDateInputValue } from '../../../utils'
+import { useStore } from '../../../store'
+import { useAuthStore } from '../../../store/authStore'
+import { TOP_BAR_HEIGHT } from '../../../constants/layout'
+
+interface Props {
+  task: Task
+  members: Member[]
+  onClose: () => void
+  onUpdated: (t: Task) => void
+  onDeleted: (id: string) => void
+}
+
+const ACCENT = '#6366f1'
+
+export function DesktopTaskDetail({ task, members, onClose, onUpdated, onDeleted }: Props) {
+  const [current, setCurrent] = useState(task)
+  const [comment, setComment] = useState('')
+  const [sendingComment, setSendingComment] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  const [activities, setActivities] = useState<Activity[]>([])
+  const { addComment, deleteTask, updateTask } = useStore()
+  const { member: authMember, isGuest } = useAuthStore()
+  const me = members.find((m) => m.id === authMember?.id) ?? members[0]
+
+  useEffect(() => {
+    setCurrent(task)
+    setConfirmDelete(false)
+    setSaveError(null)
+    setDeleteError(null)
+  }, [task.id])
+
+  const fetchActivities = useCallback(async () => {
+    if (isGuest) { setActivities([]); return }
+    try {
+      const data = await tasksApi.getActivity(current.id)
+      setActivities(data)
+    } catch {}
+  }, [current.id, isGuest])
+
+  useEffect(() => { fetchActivities() }, [fetchActivities])
+
+  const patch = async (payload: UpdateTaskPayload) => {
+    const previous = current
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const updated = await updateTask(current.id, payload)
+      setCurrent(updated)
+      onUpdated(updated)
+      fetchActivities()
+    } catch {
+      setCurrent(previous)
+      setSaveError('Could not save change. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleAddComment = async () => {
+    if (!comment.trim() || !me || sendingComment) return
+    const body = comment.trim()
+    setComment('')
+    setSendingComment(true)
+    try {
+      await addComment(current.id, body)
+      const fresh = useStore.getState().tasks.find((t) => t.id === current.id)
+      if (fresh) setCurrent(fresh)
+    } catch {
+      setComment(body)
+    } finally {
+      setSendingComment(false)
+      fetchActivities()
+    }
+  }
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await deleteTask(current.id)
+      onDeleted(current.id)
+      onClose()
+    } catch {
+      setDeleteError('Could not delete task. Please try again.')
+      setConfirmDelete(false)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  type FeedItem = { type: 'comment'; data: NonNullable<Task['comments']>[number]; ts: string }
+               | { type: 'activity'; data: Activity; ts: string }
+  const feed: FeedItem[] = [
+    ...(current.comments ?? []).map((c) => ({ type: 'comment' as const, data: c, ts: c.created_at })),
+    ...activities.map((a) => ({ type: 'activity' as const, data: a, ts: a.created_at })),
+  ].sort((a, b) => a.ts.localeCompare(b.ts))
+
+  return (
+    <div style={{
+      width: 400,
+      flexShrink: 0,
+      borderLeft: '1px solid #ede8e1',
+      background: '#faf7f2',
+      position: 'sticky',
+      top: TOP_BAR_HEIGHT,
+      height: `calc(100vh - ${TOP_BAR_HEIGHT}px)`,
+      overflowY: 'auto',
+      display: 'flex',
+      flexDirection: 'column',
+    }}>
+      {/* Panel header */}
+      <div style={{
+        position: 'sticky', top: 0, background: '#faf7f2',
+        padding: '14px 16px 10px', borderBottom: '1px solid #ede8e1', zIndex: 1,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: CATEGORIES[current.category].color }}>
+              {CATEGORIES[current.category].label}
+            </span>
+            <span style={{ width: 3, height: 3, borderRadius: '50%', background: '#d4d4d8', display: 'inline-block' }} />
+            <span style={{ fontSize: 12, fontWeight: 600, color: PRIORITIES[current.priority].color }}>
+              {PRIORITIES[current.priority].label}
+            </span>
+            {saving && <span style={{ fontSize: 11, color: '#a8a29e', marginLeft: 4 }}>Saving…</span>}
+          </div>
+          <button
+            onClick={onClose}
+            style={{ background: '#ede8e1', border: 'none', borderRadius: 7, padding: '5px 12px', fontSize: 13, color: '#78716c', cursor: 'pointer' }}
+          >✕</button>
+        </div>
+      </div>
+
+      <div style={{ padding: '12px 12px', flex: 1 }}>
+        {/* Identity */}
+        <div style={{ background: 'white', borderRadius: 12, padding: '14px 14px 4px', marginBottom: 8, border: '1px solid #ede8e1' }}>
+          <input
+            value={current.title}
+            onChange={(e) => setCurrent({ ...current, title: e.target.value })}
+            onBlur={() => patch({ title: current.title })}
+            disabled={saving}
+            placeholder="Task title"
+            style={{ width: '100%', fontSize: 16, fontWeight: 700, border: 'none', outline: 'none', background: 'transparent', marginBottom: 10, color: '#1c1917', boxSizing: 'border-box' }}
+          />
+          <input
+            value={current.notes}
+            onChange={(e) => setCurrent({ ...current, notes: e.target.value })}
+            onBlur={() => patch({ notes: current.notes })}
+            placeholder="Add notes…"
+            style={{ width: '100%', fontSize: 13, border: 'none', borderTop: '1px solid #faf7f2', outline: 'none', background: 'transparent', padding: '10px 0', color: '#78716c', boxSizing: 'border-box' }}
+          />
+        </div>
+
+        {/* Classification */}
+        <div style={{ background: 'white', borderRadius: 12, padding: '14px', marginBottom: 8, border: '1px solid #ede8e1' }}>
+          <FieldLabel>Category</FieldLabel>
+          <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
+            {(Object.entries(CATEGORIES) as [string, { label: string; color: string }][]).map(([k, v]) => (
+              <PillBtn key={k} active={current.category === k} color={v.color} onClick={() => patch({ category: k as Category })}>
+                {v.label}
+              </PillBtn>
+            ))}
+          </div>
+          <div style={{ height: 1, background: '#faf7f2', marginBottom: 14 }} />
+          <FieldLabel>Priority</FieldLabel>
+          <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
+            {(Object.entries(PRIORITIES) as [string, { label: string; color: string }][]).map(([k, v]) => (
+              <PillBtn key={k} active={current.priority === k} color={v.color} onClick={() => patch({ priority: k as Priority })}>
+                {v.label}
+              </PillBtn>
+            ))}
+          </div>
+          <div style={{ height: 1, background: '#faf7f2', marginBottom: 14 }} />
+          <FieldLabel>Assign to</FieldLabel>
+          <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
+            {members.map((m) => (
+              <PillBtn key={m.id} active={current.assignee_id === m.id} color={m.color} onClick={() => patch({ assignee_id: m.id })}>
+                {m.name}
+              </PillBtn>
+            ))}
+          </div>
+          <div style={{ height: 1, background: '#faf7f2', marginBottom: 14 }} />
+          <FieldLabel>Due date</FieldLabel>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <input
+              type="date"
+              value={current.due_at ? toDateInputValue(current.due_at) : ''}
+              onChange={(e) => {
+                const val = e.target.value ? new Date(e.target.value).toISOString() : undefined
+                setCurrent({ ...current, due_at: val })
+                patch(val ? { due_at: val } : { clear_due_at: true })
+              }}
+              style={{ flex: 1, fontSize: 13, border: '1px solid #ede8e1', borderRadius: 8, padding: '8px 10px', outline: 'none', background: '#f9f9f9', color: '#1c1917' }}
+            />
+            {current.due_at && (
+              <button
+                onClick={() => { setCurrent({ ...current, due_at: undefined }); patch({ clear_due_at: true }) }}
+                style={{ fontSize: 12, color: '#a8a29e', background: '#faf7f2', border: 'none', borderRadius: 7, padding: '7px 10px', cursor: 'pointer' }}
+              >Clear</button>
+            )}
+          </div>
+        </div>
+
+        {/* Activity */}
+        <div style={{ background: 'white', borderRadius: 12, padding: '14px', marginBottom: 8, border: '1px solid #ede8e1' }}>
+          <FieldLabel>Activity</FieldLabel>
+          {feed.length === 0 && (
+            <p style={{ fontSize: 13, color: '#a8a29e', margin: '0 0 12px' }}>No activity yet.</p>
+          )}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: feed.length > 0 ? 14 : 0 }}>
+            {feed.map((item) =>
+              item.type === 'comment' ? (
+                <div key={item.data.id} style={{ display: 'flex', gap: 8 }}>
+                  {item.data.author
+                    ? <Avatar member={item.data.author} size={26} />
+                    : <div style={{ width: 26, height: 26, borderRadius: '50%', background: '#ede8e1', flexShrink: 0 }} />
+                  }
+                  <div style={{ background: '#faf7f2', borderRadius: 10, padding: '8px 10px', flex: 1 }}>
+                    <div style={{ fontSize: 11, fontWeight: 600, color: '#a8a29e', marginBottom: 3 }}>
+                      {item.data.author?.name ?? 'Unknown'} · {timeAgo(item.data.created_at)}
+                    </div>
+                    <div style={{ fontSize: 13, color: '#1c1917' }}>{item.data.body}</div>
+                  </div>
+                </div>
+              ) : (
+                <div key={item.data.id} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                  {item.data.actor
+                    ? <Avatar member={item.data.actor} size={22} />
+                    : <div style={{ width: 22, height: 22, borderRadius: '50%', background: '#ede8e1', flexShrink: 0 }} />
+                  }
+                  <span style={{ fontSize: 12, color: '#78716c', lineHeight: 1.4 }}>
+                    <span style={{ fontWeight: 600, color: '#52525b' }}>{item.data.actor?.name ?? 'Someone'}</span>
+                    {' '}{describeActivity(item.data)}
+                    <span style={{ color: '#a8a29e' }}> · {timeAgo(item.data.created_at)}</span>
+                  </span>
+                </div>
+              )
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <input
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleAddComment()}
+              placeholder="Add a comment…"
+              style={{ flex: 1, fontSize: 13, border: '1px solid #ede8e1', borderRadius: 8, padding: '9px 10px', outline: 'none', background: '#f9f9f9' }}
+            />
+            <button
+              onClick={handleAddComment}
+              disabled={sendingComment || !comment.trim()}
+              style={{
+                background: sendingComment ? '#c7d2fe' : ACCENT, color: 'white', border: 'none',
+                borderRadius: 8, padding: '0 14px', fontSize: 16, cursor: sendingComment ? 'not-allowed' : 'pointer',
+              }}
+            >{sendingComment ? '…' : '↑'}</button>
+          </div>
+        </div>
+
+        {/* Danger zone */}
+        <div style={{ marginBottom: 24 }}>
+          {saveError && <div style={{ padding: '8px 12px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca', marginBottom: 10 }}>{saveError}</div>}
+          {deleteError && <div style={{ padding: '8px 12px', borderRadius: 8, background: '#fef2f2', color: '#ef4444', fontSize: 12, border: '1px solid #fecaca', marginBottom: 10 }}>{deleteError}</div>}
+          {confirmDelete ? (
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button onClick={() => setConfirmDelete(false)} style={{ flex: 1, background: 'white', border: '1px solid #ede8e1', borderRadius: 10, padding: 12, color: '#78716c', fontWeight: 600, fontSize: 14, cursor: 'pointer' }}>Cancel</button>
+              <button onClick={handleDelete} disabled={deleting} style={{ flex: 1, background: deleting ? '#fca5a5' : '#ef4444', border: 'none', borderRadius: 10, padding: 12, color: 'white', fontWeight: 700, fontSize: 14, cursor: deleting ? 'not-allowed' : 'pointer' }}>
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          ) : (
+            <button onClick={() => setConfirmDelete(true)} style={{ width: '100%', background: 'transparent', border: 'none', padding: '12px 0', color: '#d4d4d8', fontWeight: 500, fontSize: 13, cursor: 'pointer' }}>
+              Delete task
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function describeActivity(a: Activity): string {
+  const m = a.meta ?? {}
+  switch (a.kind) {
+    case 'created':          return 'created this task'
+    case 'completed':        return 'marked as complete'
+    case 'reopened':         return 'reopened'
+    case 'assigned':         return `changed assignee from ${m.from || '—'} to ${m.to || '—'}`
+    case 'priority_changed': return `changed priority to ${m.to}`
+    case 'category_changed': return `changed category to ${m.to}`
+    case 'title_changed':    return `renamed to "${m.to}"`
+    case 'notes_changed':    return 'updated the notes'
+    case 'due_set':          return `set due date to ${m.to}`
+    case 'due_cleared':      return 'removed the due date'
+    default:                 return a.kind
+  }
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <p style={{ fontSize: 10, fontWeight: 700, color: '#a8a29e', letterSpacing: 0.8, textTransform: 'uppercase', margin: '0 0 8px' }}>{children}</p>
+}
+
+function PillBtn({ children, active, color, onClick }: { children: React.ReactNode; active: boolean; color: string; onClick: () => void }) {
+  return (
+    <button onClick={onClick} style={{ padding: '5px 12px', borderRadius: 99, border: '1px solid', fontWeight: 600, fontSize: 12, cursor: 'pointer', borderColor: active ? color : '#ede8e1', background: active ? color + '14' : 'white', color: active ? color : '#78716c', transition: 'all 0.12s' }}>
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -6,6 +6,8 @@ import { TaskCard } from '../components/tasks/TaskCard'
 import { TaskDrawer } from '../components/tasks/TaskDrawer'
 import { AddTaskSheet } from '../components/tasks/AddTaskSheet'
 import { Spinner } from '../components/ui/Spinner'
+import { DesktopTaskDetail } from '../components/layout/desktop/DesktopTaskDetail'
+import { useBreakpoint } from '../hooks/useBreakpoint'
 import { CATEGORIES, type Task, type Category } from '../types'
 
 type FilterStatus = 'open' | 'done' | 'all'
@@ -25,6 +27,7 @@ export function TasksPage() {
   const [showAdd, setShowAdd] = useState(false)
   const [undoTask, setUndoTask] = useState<{ id: string } | null>(null)
   const [undoTimer, setUndoTimer] = useState<ReturnType<typeof setTimeout> | null>(null)
+  const isDesktop = useBreakpoint()
   const refresh = useCallback(() => fetchTasks(), [fetchTasks])
 
   const handleToggle = useCallback(async (id: string, done: boolean) => {
@@ -214,55 +217,61 @@ export function TasksPage() {
         >{sortBy === 'priority' ? 'Sort: Priority' : 'Sort: Recent'}</button>
       </div>
 
-      {/* Content */}
-      <div style={{ padding: '4px 12px 140px' }}>
-        {loading ? (
-          <Spinner />
-        ) : tasks.length === 0 ? (
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '72px 24px 32px', textAlign: 'center' }}>
-            <div style={{
-              width: 64, height: 64, borderRadius: 20, background: '#eef2ff',
-              display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 20,
-            }}>
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke={ACCENT} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M9 11l3 3L22 4" />
-                <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
-              </svg>
+      {/* Content — two columns on desktop, single column on mobile */}
+      <div style={{ display: 'flex', flex: 1 }}>
+        <div style={{ flex: 1, padding: '4px 12px', paddingBottom: isDesktop ? 40 : 140, minWidth: 0 }}>
+          {loading ? (
+            <Spinner />
+          ) : tasks.length === 0 ? (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '72px 24px 32px', textAlign: 'center' }}>
+              <div style={{
+                width: 64, height: 64, borderRadius: 20, background: '#eef2ff',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 20,
+              }}>
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke={ACCENT} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M9 11l3 3L22 4" />
+                  <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
+                </svg>
+              </div>
+              <h2 style={{ fontSize: 18, fontWeight: 700, color: '#1c1917', margin: '0 0 6px' }}>No tasks yet</h2>
+              <p style={{ fontSize: 13, color: '#a8a29e', margin: '0 0 24px', lineHeight: 1.6, maxWidth: 240 }}>
+                {isGuest ? 'Add a few preview tasks to try the app locally.' : 'Add your household\'s first task to get started.'}
+              </p>
+              <button
+                onClick={() => setShowAdd(true)}
+                style={{ padding: '10px 24px', borderRadius: 8, border: 'none', background: ACCENT, color: 'white', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
+              >Add first task</button>
             </div>
-            <h2 style={{ fontSize: 18, fontWeight: 700, color: '#1c1917', margin: '0 0 6px' }}>No tasks yet</h2>
-            <p style={{ fontSize: 13, color: '#a8a29e', margin: '0 0 24px', lineHeight: 1.6, maxWidth: 240 }}>
-              {isGuest ? 'Add a few preview tasks to try the app locally.' : 'Add your household\'s first task to get started.'}
-            </p>
-            <button
-              onClick={() => setShowAdd(true)}
-              style={{
-                padding: '10px 24px', borderRadius: 8, border: 'none',
-                background: ACCENT, color: 'white', fontSize: 13, fontWeight: 700, cursor: 'pointer',
-              }}
-            >Add first task</button>
-          </div>
-        ) : visible.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '64px 20px' }}>
-            <p style={{ fontSize: 18, fontWeight: 700, color: '#1c1917' }}>All clear!</p>
-            <p style={{ fontSize: 13, color: '#a8a29e', marginTop: 6, marginBottom: 20 }}>Nothing matches these filters.</p>
-            <button
-              onClick={() => { setCatTab('all'); setFilterStatus('open'); setMyTasks(false); setSearch('') }}
-              style={{
-                padding: '8px 20px', borderRadius: 8, border: '1px solid #ede8e1',
-                background: 'white', color: '#78716c', fontSize: 12, fontWeight: 600, cursor: 'pointer',
-              }}
-            >Reset filters</button>
-          </div>
-        ) : visible.map((task) => (
-          <TaskCard key={task.id} task={task} onToggle={handleToggle} onOpen={setSelected} />
-        ))}
+          ) : visible.length === 0 ? (
+            <div style={{ textAlign: 'center', padding: '64px 20px' }}>
+              <p style={{ fontSize: 18, fontWeight: 700, color: '#1c1917' }}>All clear!</p>
+              <p style={{ fontSize: 13, color: '#a8a29e', marginTop: 6, marginBottom: 20 }}>Nothing matches these filters.</p>
+              <button
+                onClick={() => { setCatTab('all'); setFilterStatus('open'); setMyTasks(false); setSearch('') }}
+                style={{ padding: '8px 20px', borderRadius: 8, border: '1px solid #ede8e1', background: 'white', color: '#78716c', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}
+              >Reset filters</button>
+            </div>
+          ) : visible.map((task) => (
+            <TaskCard key={task.id} task={task} onToggle={handleToggle} onOpen={setSelected} />
+          ))}
+        </div>
+
+        {/* Desktop detail panel */}
+        {isDesktop && selected && (
+          <DesktopTaskDetail
+            task={selected} members={members}
+            onClose={() => setSelected(null)}
+            onUpdated={(t) => { setSelected(t); refresh() }}
+            onDeleted={(id) => { deleteTask(id); setSelected(null) }}
+          />
+        )}
       </div>
 
       {/* FAB */}
       <button
         onClick={() => setShowAdd(true)}
         style={{
-          position: 'fixed', bottom: 72, right: 20, width: 50, height: 50,
+          position: 'fixed', bottom: isDesktop ? 24 : 72, right: 24, width: 50, height: 50,
           borderRadius: 14, background: ACCENT, color: 'white', border: 'none',
           fontSize: 24, display: 'flex', alignItems: 'center', justifyContent: 'center',
           boxShadow: '0 4px 16px rgba(99,102,241,0.35)', zIndex: 40, cursor: 'pointer',
@@ -272,8 +281,8 @@ export function TasksPage() {
         onMouseUp={(e) => (e.currentTarget.style.transform = 'scale(1)')}
       >+</button>
 
-      {/* Modals */}
-      {selected && (
+      {/* Mobile drawer — only on mobile */}
+      {!isDesktop && selected && (
         <TaskDrawer
           task={selected} members={members}
           onClose={() => setSelected(null)}


### PR DESCRIPTION
## What
Desktop-optimised Tasks page: task list on the left, detail panel on the right.

## Changes
- `DesktopTaskDetail` — inline panel (sticky, 400px) with full edit/comment/delete capability. Renders without overlay or slide-up animation.
- `TasksPage` — imports `useBreakpoint`; on desktop renders two-column layout and uses `DesktopTaskDetail` instead of `TaskDrawer`. FAB repositioned to `bottom: 24px` (no bottom nav on desktop).
- Mobile path is unchanged — `TaskDrawer` still renders on narrow viewports.

## Checklist
- [x] `make up` — runs locally
- [x] `npm run build` passes
- [x] Mobile layout unchanged