### PR TITLE
feat(desktop): Household page — side-by-side panel + member list

### DIFF
--- a/frontend/src/pages/MembersPage.tsx
+++ b/frontend/src/pages/MembersPage.tsx
@@ -3,9 +3,12 @@ import { useAuthStore } from '../store/authStore'
 import { MembersScreen } from '../components/members/MembersScreen'
 import { HouseholdPanel } from '../components/members/HouseholdPanel'
 import { GuestOnlyNotice } from '../components/ui/GuestOnlyNotice'
+import { useBreakpoint } from '../hooks/useBreakpoint'
+
 export function MembersPage() {
   const { tasks, members } = useStore()
   const { member, isGuest } = useAuthStore()
+  const isDesktop = useBreakpoint()
 
   return (
     <>
@@ -20,16 +23,32 @@ export function MembersPage() {
           title="Households need a real account"
           description="Guest mode lets you preview task management locally. Create an account to invite people, join a household, and sync updates in real time."
         />
+      ) : isDesktop ? (
+        <div style={{ display: 'flex', alignItems: 'flex-start' }}>
+          <div style={{ width: 380, flexShrink: 0, borderRight: '1px solid #ede8e1' }}>
+            <HouseholdPanel />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {!!member?.household_id && (
+              <MembersScreen
+                tasks={tasks}
+                members={members}
+                currentMember={member}
+                isAdmin={member.role === 'admin'}
+              />
+            )}
+          </div>
+        </div>
       ) : (
         <>
           <HouseholdPanel />
           {!!member?.household_id && (
-        <MembersScreen
-          tasks={tasks}
-          members={members}
-          currentMember={member}
-          isAdmin={member.role === 'admin'}
-        />
+            <MembersScreen
+              tasks={tasks}
+              members={members}
+              currentMember={member}
+              isAdmin={member.role === 'admin'}
+            />
           )}
         </>
       )}


### PR DESCRIPTION
## What
Desktop two-column layout for the Household page.

## Changes
- `MembersPage` — imports `useBreakpoint`; on desktop renders `HouseholdPanel` (380px left) alongside `MembersScreen` (flex right)
- Mobile stacked layout completely unchanged

## Checklist
- [x] `make up` — runs locally
- [x] `npm run build` passes