### PR TITLE
feat: task status phases — open, in_progress, on_hold, done

### DIFF
--- a/backend/internal/db/migrations/000018_add_task_status.down.sql
+++ b/backend/internal/db/migrations/000018_add_task_status.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_tasks_status;
+ALTER TABLE tasks DROP COLUMN IF EXISTS status;

--- a/backend/internal/db/migrations/000018_add_task_status.up.sql
+++ b/backend/internal/db/migrations/000018_add_task_status.up.sql
@@ -1,0 +1,9 @@
+-- Add status column to tasks for multi-phase workflow (open, in_progress, on_hold, done)
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'open'
+    CHECK (status IN ('open', 'in_progress', 'on_hold', 'done'));
+
+-- Backfill from existing done boolean
+UPDATE tasks SET status = CASE WHEN done THEN 'done' ELSE 'open' END;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);

--- a/backend/internal/domain/activity.go
+++ b/backend/internal/domain/activity.go
@@ -19,6 +19,7 @@ const (
 	ActivityNotesChanged    ActivityKind = "notes_changed"
 	ActivityDueSet          ActivityKind = "due_set"
 	ActivityDueCleared      ActivityKind = "due_cleared"
+	ActivityStatusChanged   ActivityKind = "status_changed"
 )
 
 // Activity is an immutable event on a task.

--- a/backend/internal/domain/task.go
+++ b/backend/internal/domain/task.go
@@ -6,6 +6,16 @@ import (
 	"github.com/google/uuid"
 )
 
+// TaskStatus represents the workflow phase of a task.
+type TaskStatus string
+
+const (
+	TaskStatusOpen       TaskStatus = "open"
+	TaskStatusInProgress TaskStatus = "in_progress"
+	TaskStatusOnHold     TaskStatus = "on_hold"
+	TaskStatusDone       TaskStatus = "done"
+)
+
 // Category represents a task category.
 type Category string
 
@@ -33,6 +43,7 @@ type Task struct {
 	Priority    Priority   `json:"priority"`
 	AssigneeID  *uuid.UUID `json:"assignee_id"`
 	HouseholdID uuid.UUID  `json:"household_id"`
+	Status      TaskStatus `json:"status"`
 	Done        bool       `json:"done"`
 	DoneAt      *time.Time `json:"done_at,omitempty"`
 	DueAt       *time.Time `json:"due_at,omitempty"`
@@ -76,10 +87,11 @@ type UpdateTaskInput struct {
 	Category   *Category  `json:"category,omitempty"`
 	Priority   *Priority  `json:"priority,omitempty"`
 	AssigneeID *uuid.UUID `json:"assignee_id,omitempty"`
-	Done       *bool      `json:"done,omitempty"`
-	DueAt      *time.Time `json:"due_at,omitempty"`
-	ClearDueAt bool       `json:"clear_due_at,omitempty"`
-	Quantity   *string    `json:"quantity,omitempty"`
+	Status     *TaskStatus `json:"status,omitempty"`
+	Done       *bool       `json:"done,omitempty"`
+	DueAt      *time.Time  `json:"due_at,omitempty"`
+	ClearDueAt bool        `json:"clear_due_at,omitempty"`
+	Quantity   *string     `json:"quantity,omitempty"`
 }
 
 // TaskFilter contains optional query filters.

--- a/backend/internal/repository/task_repo.go
+++ b/backend/internal/repository/task_repo.go
@@ -56,7 +56,7 @@ func NewTaskRepository(db *pgxpool.Pool) domain.TaskRepository {
 
 const taskSelectCols = `
 	t.id, t.title, t.notes, t.category, t.priority,
-	t.assignee_id, t.household_id, t.done, t.done_at, t.due_at, t.quantity, t.created_at, t.updated_at,
+	t.assignee_id, t.household_id, t.status, t.done, t.done_at, t.due_at, t.quantity, t.created_at, t.updated_at,
 	m.id, COALESCE(m.name, ''), COALESCE(m.avatar, ''), COALESCE(m.color, ''), m.created_at
 `
 
@@ -67,7 +67,7 @@ func scanTaskWithMember(row pgx.Row) (*domain.Task, error) {
 	var mCreatedAt *time.Time
 	err := row.Scan(
 		&t.ID, &t.Title, &t.Notes, &t.Category, &t.Priority,
-		&t.AssigneeID, &t.HouseholdID, &t.Done, &t.DoneAt, &t.DueAt, &t.Quantity, &t.CreatedAt, &t.UpdatedAt,
+		&t.AssigneeID, &t.HouseholdID, &t.Status, &t.Done, &t.DoneAt, &t.DueAt, &t.Quantity, &t.CreatedAt, &t.UpdatedAt,
 		&mID, &mName, &mAvatar, &mColor, &mCreatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -142,7 +142,7 @@ func (r *taskRepo) FindAll(filter domain.TaskFilter) ([]domain.Task, error) {
 		var mCreatedAt *time.Time
 		if err := rows.Scan(
 			&t.ID, &t.Title, &t.Notes, &t.Category, &t.Priority,
-			&t.AssigneeID, &t.HouseholdID, &t.Done, &t.DoneAt, &t.DueAt, &t.Quantity, &t.CreatedAt, &t.UpdatedAt,
+			&t.AssigneeID, &t.HouseholdID, &t.Status, &t.Done, &t.DoneAt, &t.DueAt, &t.Quantity, &t.CreatedAt, &t.UpdatedAt,
 			&mID, &mName, &mAvatar, &mColor, &mCreatedAt,
 		); err != nil {
 			return nil, err
@@ -242,18 +242,43 @@ func (r *taskRepo) Update(id uuid.UUID, input domain.UpdateTaskInput) (*domain.T
 		args = append(args, *input.AssigneeID)
 		i++
 	}
-	if input.Done != nil {
-		setClauses = append(setClauses, fmt.Sprintf("done = $%d", i))
-		args = append(args, *input.Done)
+	if input.Status != nil {
+		// Status is the source of truth; keep done/done_at in sync.
+		isDone := *input.Status == domain.TaskStatusDone
+		setClauses = append(setClauses, fmt.Sprintf("status = $%d", i))
+		args = append(args, string(*input.Status))
 		i++
-		if *input.Done {
-			now := time.Now()
+		setClauses = append(setClauses, fmt.Sprintf("done = $%d", i))
+		args = append(args, isDone)
+		i++
+		if isDone {
 			setClauses = append(setClauses, fmt.Sprintf("done_at = $%d", i))
-			args = append(args, now)
+			args = append(args, time.Now())
 			i++
 		} else {
 			setClauses = append(setClauses, fmt.Sprintf("done_at = $%d", i))
 			args = append(args, nil)
+			i++
+		}
+	} else if input.Done != nil {
+		// Backward-compat: Done toggle derives status (open ↔ done only).
+		isDone := *input.Done
+		setClauses = append(setClauses, fmt.Sprintf("done = $%d", i))
+		args = append(args, isDone)
+		i++
+		if isDone {
+			setClauses = append(setClauses, fmt.Sprintf("done_at = $%d", i))
+			args = append(args, time.Now())
+			i++
+			setClauses = append(setClauses, fmt.Sprintf("status = $%d", i))
+			args = append(args, string(domain.TaskStatusDone))
+			i++
+		} else {
+			setClauses = append(setClauses, fmt.Sprintf("done_at = $%d", i))
+			args = append(args, nil)
+			i++
+			setClauses = append(setClauses, fmt.Sprintf("status = $%d", i))
+			args = append(args, string(domain.TaskStatusOpen))
 			i++
 		}
 	}

--- a/backend/internal/service/task_service.go
+++ b/backend/internal/service/task_service.go
@@ -66,6 +66,9 @@ func (s *TaskService) UpdateTask(id uuid.UUID, input domain.UpdateTaskInput, act
 	if callerHouseholdID != nil && old.HouseholdID != *callerHouseholdID {
 		return nil, domain.ErrNotFound
 	}
+	if input.Status != nil && !validStatus(*input.Status) {
+		return nil, fmt.Errorf("%w: invalid status", domain.ErrInvalidInput)
+	}
 	if input.Category != nil && !validCategory(*input.Category) {
 		return nil, fmt.Errorf("%w: invalid category", domain.ErrInvalidInput)
 	}
@@ -129,7 +132,17 @@ func (s *TaskService) GetActivity(taskID uuid.UUID, callerHouseholdID *uuid.UUID
 
 // recordUpdateActivities diffs old vs new task and creates an activity for each changed field.
 func (s *TaskService) recordUpdateActivities(old, new *domain.Task, input domain.UpdateTaskInput, actorID *uuid.UUID) {
-	if input.Done != nil && *input.Done != old.Done {
+	if input.Status != nil && *input.Status != old.Status {
+		if *input.Status == domain.TaskStatusDone {
+			s.activities.Create(new.ID, actorID, domain.ActivityCompleted, nil) //nolint:errcheck
+		} else if old.Status == domain.TaskStatusDone {
+			s.activities.Create(new.ID, actorID, domain.ActivityReopened, nil) //nolint:errcheck
+		}
+		s.activities.Create(new.ID, actorID, domain.ActivityStatusChanged, map[string]string{ //nolint:errcheck
+			"from": string(old.Status),
+			"to":   string(*input.Status),
+		})
+	} else if input.Done != nil && *input.Done != old.Done {
 		kind := domain.ActivityReopened
 		if *input.Done {
 			kind = domain.ActivityCompleted
@@ -205,6 +218,14 @@ func (s *TaskService) validateTaskInput(title string, category domain.Category, 
 		}
 	}
 	return nil
+}
+
+func validStatus(s domain.TaskStatus) bool {
+	switch s {
+	case domain.TaskStatusOpen, domain.TaskStatusInProgress, domain.TaskStatusOnHold, domain.TaskStatusDone:
+		return true
+	}
+	return false
 }
 
 func validCategory(c domain.Category) bool {

--- a/frontend/src/components/layout/desktop/DesktopTaskDetail.tsx
+++ b/frontend/src/components/layout/desktop/DesktopTaskDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Avatar } from '../../ui/Avatar'
-import { CATEGORIES, PRIORITIES, type Task, type Member, type UpdateTaskPayload, type Category, type Priority, type Activity } from '../../../types'
+import { CATEGORIES, PRIORITIES, STATUSES, type Task, type Member, type UpdateTaskPayload, type Category, type Priority, type TaskStatus, type Activity } from '../../../types'
 import { tasksApi } from '../../../api/tasks'
 import { timeAgo, toDateInputValue } from '../../../utils'
 import { useStore } from '../../../store'
@@ -162,6 +162,15 @@ export function DesktopTaskDetail({ task, members, onClose, onUpdated, onDeleted
 
         {/* Classification */}
         <div style={{ background: 'white', borderRadius: 12, padding: '14px', marginBottom: 8, border: '1px solid #ede8e1' }}>
+          <FieldLabel>Status</FieldLabel>
+          <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
+            {(Object.entries(STATUSES) as [TaskStatus, { label: string; color: string }][]).map(([k, v]) => (
+              <PillBtn key={k} active={(current.status ?? 'open') === k} color={v.color} onClick={() => patch({ status: k })}>
+                {v.label}
+              </PillBtn>
+            ))}
+          </div>
+          <div style={{ height: 1, background: '#faf7f2', marginBottom: 14 }} />
           <FieldLabel>Category</FieldLabel>
           <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
             {(Object.entries(CATEGORIES) as [string, { label: string; color: string }][]).map(([k, v]) => (
@@ -300,6 +309,7 @@ function describeActivity(a: Activity): string {
     case 'notes_changed':    return 'updated the notes'
     case 'due_set':          return `set due date to ${m.to}`
     case 'due_cleared':      return 'removed the due date'
+    case 'status_changed':   return `moved to ${STATUSES[m.to as TaskStatus]?.label ?? m.to}`
     default:                 return a.kind
   }
 }

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Avatar } from '../ui/Avatar'
-import { CATEGORIES, PRIORITIES, type Task } from '../../types'
+import { CATEGORIES, PRIORITIES, STATUSES, type Task } from '../../types'
 import { formatDate, isOverdue, isDueSoon } from '../../utils'
 
 interface Props {
@@ -12,6 +12,7 @@ interface Props {
 export function TaskCard({ task, onToggle, onOpen }: Props) {
   const [popping, setPopping] = useState(false)
   const cat = CATEGORIES[task.category]
+  const statusInfo = STATUSES[task.status ?? 'open']
   const overdue = isOverdue(task.due_at, task.done)
   const dueSoon = isDueSoon(task.due_at, task.done)
 
@@ -68,16 +69,22 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
           display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden',
         }}>{task.title}</p>
 
-        {/* Category + notes */}
+        {/* Category + status + notes */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: (task.due_at && !task.done) || (task.comments?.length ?? 0) > 0 ? 4 : 0 }}>
           <span style={{
             fontSize: 11, fontWeight: 600, padding: '2px 7px', borderRadius: 5,
             background: cat.color + '12', color: cat.color,
           }}>{cat.label}</span>
+          {!task.done && task.status !== 'open' && (
+            <span style={{
+              fontSize: 11, fontWeight: 600, padding: '2px 7px', borderRadius: 5,
+              background: statusInfo.color + '15', color: statusInfo.color,
+            }}>{statusInfo.label}</span>
+          )}
           {task.notes && (
             <span style={{
               fontSize: 12, color: '#a8a29e',
-              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 110,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 100,
             }}>{task.notes}</span>
           )}
         </div>

--- a/frontend/src/components/tasks/TaskDrawer.tsx
+++ b/frontend/src/components/tasks/TaskDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { Avatar } from '../ui/Avatar'
-import { CATEGORIES, PRIORITIES, type Task, type Member, type UpdateTaskPayload, type Category, type Priority, type Activity } from '../../types'
+import { CATEGORIES, PRIORITIES, STATUSES, type Task, type Member, type UpdateTaskPayload, type Category, type Priority, type TaskStatus, type Activity } from '../../types'
 import { tasksApi } from '../../api/tasks'
 import { timeAgo, toDateInputValue } from '../../utils'
 import { useStore } from '../../store'
@@ -187,6 +187,17 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
 
         {/* Zone 2: Classification */}
         <div style={{ background: 'white', margin: '0 10px', borderRadius: 12, padding: '14px 14px', marginBottom: 8, border: '1px solid #ede8e1' }}>
+          <FieldLabel>Status</FieldLabel>
+          <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
+            {(Object.entries(STATUSES) as [TaskStatus, { label: string; color: string }][]).map(([k, v]) => (
+              <PillBtn key={k} active={(current.status ?? 'open') === k} color={v.color} onClick={() => patch({ status: k })}>
+                {v.label}
+              </PillBtn>
+            ))}
+          </div>
+
+          <div style={{ height: 1, background: '#faf7f2', marginBottom: 14 }} />
+
           <FieldLabel>Category</FieldLabel>
           <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
             {(Object.entries(CATEGORIES) as [string, { label: string; color: string }][]).map(([k, v]) => (
@@ -349,6 +360,7 @@ function describeActivity(a: Activity): string {
     case 'notes_changed':    return 'updated the notes'
     case 'due_set':          return `set due date to ${m.to}`
     case 'due_cleared':      return 'removed the due date'
+    case 'status_changed':   return `moved to ${STATUSES[m.to as TaskStatus]?.label ?? m.to}`
     default:                 return a.kind
   }
 }

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -63,7 +63,13 @@ export function TasksPage() {
     .sort((a, b) => {
       if (sortBy === 'recent') return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
       const po: Record<string, number> = { urgent: 0, high: 1, normal: 2 }
-      return ((a.done ? 10 : 0) + po[a.priority]) - ((b.done ? 10 : 0) + po[b.priority])
+      const so: Record<string, number> = { in_progress: 0, open: 1, on_hold: 2, done: 3 }
+      const aDone = a.done ? 1 : 0
+      const bDone = b.done ? 1 : 0
+      if (aDone !== bDone) return aDone - bDone
+      const statusDiff = (so[a.status ?? 'open'] ?? 1) - (so[b.status ?? 'open'] ?? 1)
+      if (statusDiff !== 0) return statusDiff
+      return po[a.priority] - po[b.priority]
     })
 
   const openCount = tasks.filter((t) => !t.done).length

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -19,10 +19,19 @@ function hydrateGuestTasks(tasks: Task[]): Task[] {
 
 function applyTaskPatch(task: Task, payload: UpdateTaskPayload, members: Member[]): Task {
   const now = new Date().toISOString()
-  const nextDone = payload.done ?? task.done
   const nextAssigneeID = payload.assignee_id !== undefined ? payload.assignee_id : task.assignee_id
   const nextDueAt = payload.clear_due_at ? undefined : payload.due_at !== undefined ? payload.due_at : task.due_at
   const nextQuantity = payload.quantity !== undefined ? payload.quantity : task.quantity
+
+  // Status is source of truth; done is derived
+  let nextStatus = payload.status ?? task.status
+  let nextDone = task.done
+  if (payload.status !== undefined) {
+    nextDone = payload.status === 'done'
+  } else if (payload.done !== undefined) {
+    nextDone = payload.done
+    nextStatus = payload.done ? 'done' : 'open'
+  }
 
   return {
     ...task,
@@ -34,6 +43,7 @@ function applyTaskPatch(task: Task, payload: UpdateTaskPayload, members: Member[
     assignee: members.find((member) => member.id === nextAssigneeID) ?? task.assignee,
     due_at: nextDueAt,
     quantity: nextQuantity,
+    status: nextStatus,
     done: nextDone,
     done_at: nextDone ? task.done_at ?? now : undefined,
     updated_at: now,
@@ -145,6 +155,7 @@ export const useStore = create<AppStore>((set, get) => ({
         category: payload.category,
         priority: payload.priority,
         assignee_id: payload.assignee_id || GUEST_MEMBER.id,
+        status: 'open',
         done: false,
         due_at: payload.due_at,
         quantity: payload.quantity,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,6 @@
 export type Category = 'chore' | 'errand' | 'repair'
 export type Priority = 'urgent' | 'high' | 'normal'
+export type TaskStatus = 'open' | 'in_progress' | 'on_hold' | 'done'
 
 export interface Member {
   id: string
@@ -16,7 +17,7 @@ export interface Comment {
 }
 export interface Task {
   id: string; title: string; notes: string; category: Category; priority: Priority
-  assignee_id: string; done: boolean; done_at?: string; due_at?: string; quantity?: string; created_at: string; updated_at: string
+  assignee_id: string; status: TaskStatus; done: boolean; done_at?: string; due_at?: string; quantity?: string; created_at: string; updated_at: string
   assignee?: Member; comments?: Comment[]
 }
 
@@ -36,7 +37,7 @@ export interface CreateTaskPayload {
 }
 export interface UpdateTaskPayload {
   title?: string; notes?: string; category?: Category; priority?: Priority
-  assignee_id?: string; done?: boolean; due_at?: string; clear_due_at?: boolean; quantity?: string
+  assignee_id?: string; status?: TaskStatus; done?: boolean; due_at?: string; clear_due_at?: boolean; quantity?: string
 }
 
 export const CATEGORIES: Record<Category, { label: string; color: string }> = {
@@ -49,11 +50,18 @@ export const PRIORITIES: Record<Priority, { label: string; color: string }> = {
   high: { label: 'High', color: '#f97316' },
   urgent: { label: 'Urgent', color: '#ef4444' },
 }
+export const STATUSES: Record<TaskStatus, { label: string; color: string }> = {
+  open:        { label: 'Open',        color: '#78716c' },
+  in_progress: { label: 'In Progress', color: '#6366f1' },
+  on_hold:     { label: 'On Hold',     color: '#d97706' },
+  done:        { label: 'Done',        color: '#22c55e' },
+}
 
 export type ActivityKind =
   | 'created' | 'completed' | 'reopened'
   | 'assigned' | 'priority_changed' | 'category_changed'
   | 'title_changed' | 'notes_changed' | 'due_set' | 'due_cleared'
+  | 'status_changed'
 
 export interface Activity {
   id: string


### PR DESCRIPTION
## Summary
Adds a 4-phase workflow to tasks replacing the binary done/not-done model.

**Statuses:**
| Status | Color | Meaning |
|--------|-------|---------|
| Open | Gray | Default, not started |
| In Progress | Indigo | Actively being worked on |
| On Hold | Amber | Paused or blocked |
| Done | Green | Completed |

**Changes:**
- Migration 000018: `status TEXT NOT NULL DEFAULT 'open' CHECK (status IN (...))` + backfill from existing `done` bool
- `done` boolean kept in sync by the repo layer — status is the source of truth
- Status picker shown at top of classification zone in TaskDrawer (mobile) and DesktopTaskDetail
- Status chip shown on TaskCard for non-open, non-done tasks
- Sort order within active tasks: in_progress → open → on_hold
- Activity feed records `status_changed` events
- Checkbox still toggles done ↔ open (quick complete/reopen); full status is via drawer

## Test plan
- [ ] Existing tasks backfilled to `open` or `done` correctly after migration
- [ ] Status picker appears in TaskDrawer — all 4 values selectable
- [ ] Selecting `Done` marks task as done (checkbox fills); selecting other statuses unmarks done
- [ ] `In Progress` chip appears on task cards; `On Hold` chip appears; `Open` and `Done` have no extra chip
- [ ] Activity feed shows "moved to In Progress" etc.
- [ ] Checkbox toggle still works (done ↔ open)
- [ ] Sort: in_progress tasks appear before open before on_hold before done

🤖 Generated with [Claude Code](https://claude.com/claude-code)