### PR TITLE
feat: replace checkbox with status icon + popover

### DIFF
--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1,26 +1,67 @@
 import { useState } from 'react'
 import { Avatar } from '../ui/Avatar'
-import { CATEGORIES, PRIORITIES, STATUSES, type Task } from '../../types'
+import { CATEGORIES, PRIORITIES, STATUSES, type Task, type TaskStatus } from '../../types'
 import { formatDate, isOverdue, isDueSoon } from '../../utils'
 
 interface Props {
   task: Task
-  onToggle: (id: string, done: boolean) => void
+  onStatusChange: (id: string, status: TaskStatus) => void
   onOpen: (task: Task) => void
 }
 
-export function TaskCard({ task, onToggle, onOpen }: Props) {
-  const [popping, setPopping] = useState(false)
+function StatusIcon({ status }: { status: TaskStatus }) {
+  const s = STATUSES[status]
+  if (status === 'done') {
+    return (
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <circle cx="10" cy="10" r="10" fill="#22c55e" />
+        <path d="M5.5 10l3 3 6-6" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    )
+  }
+  if (status === 'in_progress') {
+    return (
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <circle cx="10" cy="10" r="9" stroke="#6366f1" strokeWidth="1.5" />
+        <circle cx="10" cy="10" r="9" stroke="#6366f1" strokeWidth="1.5"
+          strokeDasharray="56.5" strokeDashoffset="28" strokeLinecap="round"
+          transform="rotate(-90 10 10)" fill="#6366f115" />
+        <circle cx="10" cy="10" r="3.5" fill="#6366f1" />
+      </svg>
+    )
+  }
+  if (status === 'on_hold') {
+    return (
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <circle cx="10" cy="10" r="9" stroke="#d97706" strokeWidth="1.5" />
+        <rect x="7" y="6.5" width="2" height="7" rx="1" fill="#d97706" />
+        <rect x="11" y="6.5" width="2" height="7" rx="1" fill="#d97706" />
+      </svg>
+    )
+  }
+  // open — empty ring
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <circle cx="10" cy="10" r="9" stroke={s.color} strokeWidth="1.5" strokeDasharray="3 2" />
+    </svg>
+  )
+}
+
+export function TaskCard({ task, onStatusChange, onOpen }: Props) {
+  const [menuOpen, setMenuOpen] = useState(false)
   const cat = CATEGORIES[task.category]
-  const statusInfo = STATUSES[task.status ?? 'open']
   const overdue = isOverdue(task.due_at, task.done)
   const dueSoon = isDueSoon(task.due_at, task.done)
 
-  const handleToggle = (e: React.MouseEvent) => {
+  const handleStatusClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    setPopping(true)
-    onToggle(task.id, !task.done)
-    setTimeout(() => setPopping(false), 400)
+    setMenuOpen((v) => !v)
+  }
+
+  const handleSelect = (e: React.MouseEvent, status: TaskStatus) => {
+    e.stopPropagation()
+    setMenuOpen(false)
+    onStatusChange(task.id, status)
   }
 
   return (
@@ -38,26 +79,71 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
         opacity: task.done ? 0.5 : 1,
         cursor: 'pointer',
         transition: 'opacity .15s',
+        position: 'relative',
       }}
     >
-      {/* Checkbox */}
+      {/* Status icon — tap to open status menu */}
       <button
-        onClick={handleToggle}
-        className={popping ? 'check-pop' : undefined}
+        onClick={handleStatusClick}
+        title="Change status"
         style={{
-          width: 20, height: 20, borderRadius: 6, marginTop: 2, flexShrink: 0,
-          border: task.done ? 'none' : '1.5px solid #d4d4d8',
-          background: task.done ? '#22c55e' : 'white',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          cursor: 'pointer', padding: 0, transition: 'background .15s',
+          flexShrink: 0, marginTop: 1, padding: 0, border: 'none', background: 'none',
+          cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          borderRadius: '50%',
         }}
       >
-        {task.done && (
-          <svg width="11" height="8" viewBox="0 0 11 8" fill="none">
-            <path d="M1 4l3 3 6-6" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        )}
+        <StatusIcon status={task.status ?? 'open'} />
       </button>
+
+      {/* Status popover */}
+      {menuOpen && (
+        <>
+          {/* Invisible backdrop to close on outside tap */}
+          <div
+            onClick={(e) => { e.stopPropagation(); setMenuOpen(false) }}
+            style={{ position: 'fixed', inset: 0, zIndex: 19 }}
+          />
+          <div style={{
+            position: 'absolute',
+            top: 32, left: 4,
+            background: 'white',
+            borderRadius: 12,
+            border: '1px solid #ede8e1',
+            boxShadow: '0 8px 28px rgba(0,0,0,0.13)',
+            zIndex: 20,
+            padding: '4px',
+            minWidth: 148,
+          }}>
+            {(Object.entries(STATUSES) as [TaskStatus, { label: string; color: string }][]).map(([k, v]) => {
+              const active = (task.status ?? 'open') === k
+              return (
+                <button
+                  key={k}
+                  onClick={(e) => handleSelect(e, k)}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 9,
+                    width: '100%', padding: '8px 10px', borderRadius: 8,
+                    border: 'none',
+                    background: active ? v.color + '12' : 'transparent',
+                    cursor: 'pointer', fontSize: 13,
+                    fontWeight: active ? 700 : 500,
+                    color: active ? v.color : '#1c1917',
+                    textAlign: 'left',
+                  }}
+                >
+                  <span style={{ width: 8, height: 8, borderRadius: '50%', background: v.color, flexShrink: 0 }} />
+                  {v.label}
+                  {active && (
+                    <svg style={{ marginLeft: 'auto' }} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke={v.color} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M20 6L9 17l-5-5" />
+                    </svg>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
 
       {/* Content */}
       <div style={{ flex: 1, minWidth: 0 }}>
@@ -69,8 +155,8 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
           display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden',
         }}>{task.title}</p>
 
-        {/* Category + status + notes */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: (task.due_at && !task.done) || (task.comments?.length ?? 0) > 0 ? 4 : 0 }}>
+        {/* Category + status chip + notes */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', marginBottom: (task.due_at && !task.done) || (task.comments?.length ?? 0) > 0 ? 4 : 0 }}>
           <span style={{
             fontSize: 11, fontWeight: 600, padding: '2px 7px', borderRadius: 5,
             background: cat.color + '12', color: cat.color,
@@ -78,8 +164,9 @@ export function TaskCard({ task, onToggle, onOpen }: Props) {
           {!task.done && task.status !== 'open' && (
             <span style={{
               fontSize: 11, fontWeight: 600, padding: '2px 7px', borderRadius: 5,
-              background: statusInfo.color + '15', color: statusInfo.color,
-            }}>{statusInfo.label}</span>
+              background: STATUSES[task.status].color + '15',
+              color: STATUSES[task.status].color,
+            }}>{STATUSES[task.status].label}</span>
           )}
           {task.notes && (
             <span style={{

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -8,7 +8,7 @@ import { AddTaskSheet } from '../components/tasks/AddTaskSheet'
 import { Spinner } from '../components/ui/Spinner'
 import { DesktopTaskDetail } from '../components/layout/desktop/DesktopTaskDetail'
 import { useBreakpoint } from '../hooks/useBreakpoint'
-import { CATEGORIES, type Task, type Category } from '../types'
+import { CATEGORIES, type Task, type Category, type TaskStatus } from '../types'
 
 type FilterStatus = 'open' | 'done' | 'all'
 type SortBy = 'priority' | 'recent'
@@ -16,7 +16,7 @@ type SortBy = 'priority' | 'recent'
 const ACCENT = '#6366f1'
 
 export function TasksPage() {
-  const { tasks, members, loading, fetchTasks, toggleTask, deleteTask } = useStore()
+  const { tasks, members, loading, fetchTasks, updateTask, deleteTask } = useStore()
   const { member, isGuest } = useAuthStore()
   const [catTab, setCatTab] = useState<Category | 'all'>('all')
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('open')
@@ -25,23 +25,20 @@ export function TasksPage() {
   const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<Task | null>(null)
   const [showAdd, setShowAdd] = useState(false)
-  const [undoTask, setUndoTask] = useState<{ id: string } | null>(null)
+  const [undoTask, setUndoTask] = useState<{ id: string; prevStatus: TaskStatus } | null>(null)
   const [undoTimer, setUndoTimer] = useState<ReturnType<typeof setTimeout> | null>(null)
   const isDesktop = useBreakpoint()
   const refresh = useCallback(() => fetchTasks(), [fetchTasks])
 
-  const handleToggle = useCallback(async (id: string, done: boolean) => {
-    await toggleTask(id, done)
-    if (done) {
-      const openAfter = useStore.getState().tasks
-        .filter((t) => !t.done)
+  const handleStatusChange = useCallback(async (id: string, status: TaskStatus) => {
+    await updateTask(id, { status })
+    if (status === 'done') {
+      const openAfter = useStore.getState().tasks.filter((t) => t.status !== 'done')
       if (openAfter.length === 0) {
         if (undoTimer) clearTimeout(undoTimer)
-        setUndoTask({ id })
-        const timer = setTimeout(() => {
-          setUndoTask(null)
-          setUndoTimer(null)
-        }, 4000)
+        const prev = tasks.find((t) => t.id === id)
+        setUndoTask({ id, prevStatus: prev?.status ?? 'open' })
+        const timer = setTimeout(() => { setUndoTask(null); setUndoTimer(null) }, 4000)
         setUndoTimer(timer)
       }
     } else if (undoTask?.id === id) {
@@ -49,7 +46,7 @@ export function TasksPage() {
       setUndoTask(null)
       setUndoTimer(null)
     }
-  }, [toggleTask, undoTask, undoTimer])
+  }, [updateTask, undoTask, undoTimer, tasks])
 
   if (!isGuest && member && !member.household_id) {
     return <Navigate to="/household" replace />
@@ -258,7 +255,7 @@ export function TasksPage() {
               >Reset filters</button>
             </div>
           ) : visible.map((task) => (
-            <TaskCard key={task.id} task={task} onToggle={handleToggle} onOpen={setSelected} />
+            <TaskCard key={task.id} task={task} onStatusChange={handleStatusChange} onOpen={setSelected} />
           ))}
         </div>
 
@@ -312,7 +309,7 @@ export function TasksPage() {
           <button
             onClick={async () => {
               if (undoTimer) clearTimeout(undoTimer)
-              await toggleTask(undoTask.id, false)
+              await updateTask(undoTask.id, { status: undoTask.prevStatus })
               setUndoTask(null)
               setUndoTimer(null)
             }}


### PR DESCRIPTION
## Summary
Removes the accident-prone checkbox and replaces it with a deliberate two-tap status flow.

**Before:** Single tap on checkbox = instant done. Easy to hit accidentally on mobile.

**After:** Tap status icon → compact menu appears → choose a status. Two intentional taps.

## Status icons (left side of each card)
| Status | Icon |
|--------|------|
| Open | Dashed gray ring |
| In Progress | Half-arc indigo ring + center dot |
| On Hold | Amber ring with pause bars |
| Done | Solid green circle with checkmark |

## Popover
- Anchored below the status icon
- 4 options with colored dots + labels; active state highlighted
- Backdrop closes it on outside tap without navigating away
- Does NOT open the task drawer

## Other
- Undo toast now restores to the previous status (not always "open")
- No backend changes — uses same `PATCH /tasks/{id}` with `{ status }`

## Test plan
- [ ] Tap card body → drawer opens (unchanged)
- [ ] Tap status icon → popover appears, card does NOT open
- [ ] Tap outside popover → closes without change
- [ ] Select each status → icon updates, chip updates on card
- [ ] Selecting Done when all tasks complete → "All tasks done!" toast appears
- [ ] Undo reverts to previous status (not always open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)