### PR TITLE
fix: mobile bottom sheet positioning on PreviewPage

### DIFF
--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -93,8 +93,7 @@ function RegisterSheet({ onClose }: RegisterSheetProps) {
       <div
         className="slide-up"
         style={{
-          position: 'fixed', bottom: 0, left: '50%', transform: 'translateX(-50%)',
-          width: '100%', maxWidth: 520,
+          position: 'fixed', bottom: 0, left: 0, right: 0,
           background: 'white',
           borderRadius: '20px 20px 0 0',
           padding: '12px 24px 40px',
@@ -210,8 +209,8 @@ function PreviewBottomNav({ onSheetOpen }: PreviewNavProps) {
 
   return (
     <div style={{
-      position: 'fixed', bottom: 0, left: '50%', transform: 'translateX(-50%)',
-      width: '100%', maxWidth: 520, background: 'white',
+      position: 'fixed', bottom: 0, left: 0, right: 0,
+      background: 'white',
       borderTop: '1px solid #ede8e1', display: 'flex',
       paddingBottom: 'env(safe-area-inset-bottom, 8px)',
       zIndex: 40,


### PR DESCRIPTION
## Summary
- Fix RegisterSheet appearing broken in bottom-right on mobile
- Replace `left:50%` + `transform:translateX(-50%)` + `maxWidth:520` with `left:0` / `right:0` on both RegisterSheet and PreviewBottomNav
- The desktop centering pattern breaks `position:fixed` rendering on mobile Safari/Chrome
- Remove all `maxWidth` desktop constraints from fixed overlay elements

## Test plan
- [ ] Open PreviewPage on a 375px mobile viewport
- [ ] Tap any task card → register sheet slides up full-width from bottom
- [ ] Tap Grocery / Stats / Household tabs → same sheet, correct position
- [ ] Backdrop tap dismisses sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)