### PR TITLE
fix: move onboarding CTA bar to natural document flow

### DIFF
--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -285,8 +285,7 @@ function NewUserCarousel() {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        padding: '0 28px',
-        paddingBottom: 160,
+        padding: '0 28px 32px',
       }}>
         {current.render()}
 
@@ -339,13 +338,9 @@ function NewUserCarousel() {
       </div>
 
       <div style={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
         background: '#faf7f2',
         padding: '16px 24px',
-        paddingBottom: 'env(safe-area-inset-bottom, 16px)',
+        paddingBottom: 'max(env(safe-area-inset-bottom, 0px), 16px)',
         borderTop: '1px solid #ede8e1',
       }}>
         <button


### PR DESCRIPTION
## Summary
- Removed `position: fixed` from the CTA bottom bar — it's now a natural flex-column footer
- Removed hardcoded `paddingBottom: 160` hack from the content area
- Used `max(env(safe-area-inset-bottom, 0px), 16px)` for correct iPhone home indicator spacing
- Buttons now sit naturally at the bottom of the screen without floating too low or overlapping content

## Root cause
`position: fixed` + a guessed 160px content offset is fragile across viewport heights. On tall phones the bar was pushed below the visible area; on short phones content would scroll behind it.

## Test plan
- [ ] iPhone SE (small screen): CTA bar sits directly below content, not floating at very bottom
- [ ] iPhone 14 Pro (tall screen): CTA bar at bottom, content vertically centered with breathing room
- [ ] Android Chrome: same behaviour, no gap between content and CTA
- [ ] "Create my account" and "Already have an account? Sign in" both visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)