### PR TITLE
fix: JoinPage sign-in flow and stale JWT after auto-join (#70 #71)

### DIFF
--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from 'react-router-dom'
 import { useAuthStore } from '../store/authStore'
 import { householdsApi } from '../api/households'
+import { authApi } from '../api/auth'
 import { AppLogo } from '../components/ui/AppLogo'
 import { LoginFlow } from '../components/auth/LoginFlow'
 import { RegisterFlow } from '../components/auth/RegisterFlow'
@@ -33,10 +34,13 @@ export function AuthPage() {
     const pendingJoin = localStorage.getItem('hj_pending_join')
     if (pendingJoin) {
       localStorage.removeItem('hj_pending_join')
+      // Temporarily persist the new auth token so the join request is authenticated
       localStorage.setItem('hj_token', token)
       try {
-        const { member: updated } = await householdsApi.joinByInviteToken(pendingJoin)
-        setAuth(token, updated)
+        await householdsApi.joinByInviteToken(pendingJoin)
+        // Refresh to get a new JWT with the updated household_id embedded
+        const { token: refreshedToken, member: refreshedMember } = await authApi.refresh()
+        setAuth(refreshedToken, refreshedMember)
         return
       } catch {}
     }


### PR DESCRIPTION
## Summary

- **#71 (JoinPage sign-in button)**: Confirmed `JoinPage.tsx` already has separate `handleSignUpAndJoin` (→ `/onboarding`) and `handleSignInAndJoin` (→ `/auth?mode=login`) handlers correctly wired to the two buttons. No code change was needed — the issue was already resolved in the current branch state.

- **#70 (stale JWT after auto-join)**: Fixed a bug in `AuthPage.handleSuccess` where, after a user signs in/registers with a pending invite token (`hj_pending_join`), the join was completed via `householdsApi.joinByInviteToken` but `setAuth` was called with the original pre-join token. That token still had `household_id: ""` in its claims. The fix calls `authApi.refresh()` after the join succeeds to get a fresh JWT with the updated `household_id` embedded, then passes the refreshed token and member to `setAuth`.

The already-authenticated auto-join path in `JoinPage.tsx` was already correct (it called `authApi.refresh()` after joining before this PR).

No backend changes were required — `POST /api/v1/auth/refresh` already re-reads the member from the DB and re-issues the token with the current `household_id`.

## Test plan

- [ ] Visit `/join/:token` as an unauthenticated user → "Sign up & join" navigates to `/onboarding` with `hj_pending_join` set
- [ ] Visit `/join/:token` as an unauthenticated user → "Sign in" navigates to `/auth?mode=login` with `hj_pending_join` set
- [ ] Complete sign-in from the above flow → household join completes, `localStorage.hj_token` contains a JWT with the correct `household_id` claim
- [ ] Complete registration from the above flow → same result
- [ ] Visit `/join/:token` as an already-authenticated user → auto-join runs, JWT refreshes, redirects to `/household` with correct `household_id` in token

Closes #70
Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)