### PR TITLE
fix: require JWT_SECRET env var — remove weak hardcoded fallback

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -15,12 +15,17 @@ type Config struct {
 }
 
 func Load() Config {
+	jwtSecret := os.Getenv("JWT_SECRET")
+	if jwtSecret == "" {
+		log.Fatal("JWT_SECRET env var is required")
+	}
+
 	cfg := Config{
 		DatabaseURL: getEnv("DATABASE_URL", "postgres://homejira:homejira_secret@localhost:5432/homejira?sslmode=disable"),
 		Port:        getEnv("PORT", "8080"),
 		Env:         getEnv("ENV", "development"),
 		CORSOrigins: getEnv("CORS_ORIGINS", "http://localhost:3000"),
-		JWTSecret:   getEnv("JWT_SECRET", "CHANGE_ME_IN_PRODUCTION_32_CHARS!"),
+		JWTSecret:   jwtSecret,
 		AppBaseURL:  getEnv("APP_BASE_URL", "http://localhost:3000"),
 	}
 	log.Printf("Config loaded: env=%s port=%s", cfg.Env, cfg.Port)


### PR DESCRIPTION
## Summary

- Removes the `"CHANGE_ME_IN_PRODUCTION_32_CHARS!"` fallback from `config/config.go`
- Server now calls `log.Fatal` on startup if `JWT_SECRET` is unset — a misconfigured deploy fails loudly rather than signing tokens with a known public string

## Type of change

- [x] Bug fix

## Issues closed

Closes #187

Also investigated #185 and #186 — both are already enforced in the current codebase (task and member handlers resolve `hhID` from DB and all service methods check household ownership). Closing those issues.

## Test plan

- [x] `go build ./...` passes
- [x] Server starts correctly when `JWT_SECRET` is set (docker-compose.yml already sets it for dev)
- [x] Verified `docker-compose.yml` has `JWT_SECRET=dev_secret_change_in_production_32ch` — local dev unaffected

## Size

XS

🤖 Generated with [Claude Code](https://claude.com/claude-code)