### PR TITLE
fix: security headers middleware and TaskDrawer unassign

### DIFF
--- a/backend/internal/domain/task.go
+++ b/backend/internal/domain/task.go
@@ -82,16 +82,17 @@ type CreateTaskInput struct {
 
 // UpdateTaskInput holds fields that may be mutated.
 type UpdateTaskInput struct {
-	Title      *string    `json:"title,omitempty"`
-	Notes      *string    `json:"notes,omitempty"`
-	Category   *Category  `json:"category,omitempty"`
-	Priority   *Priority  `json:"priority,omitempty"`
-	AssigneeID *uuid.UUID `json:"assignee_id,omitempty"`
-	Status     *TaskStatus `json:"status,omitempty"`
-	Done       *bool       `json:"done,omitempty"`
-	DueAt      *time.Time  `json:"due_at,omitempty"`
-	ClearDueAt bool        `json:"clear_due_at,omitempty"`
-	Quantity   *string     `json:"quantity,omitempty"`
+	Title           *string     `json:"title,omitempty"`
+	Notes           *string     `json:"notes,omitempty"`
+	Category        *Category   `json:"category,omitempty"`
+	Priority        *Priority   `json:"priority,omitempty"`
+	AssigneeID      *uuid.UUID  `json:"assignee_id,omitempty"`
+	ClearAssigneeID bool        `json:"clear_assignee_id,omitempty"`
+	Status          *TaskStatus `json:"status,omitempty"`
+	Done            *bool       `json:"done,omitempty"`
+	DueAt           *time.Time  `json:"due_at,omitempty"`
+	ClearDueAt      bool        `json:"clear_due_at,omitempty"`
+	Quantity        *string     `json:"quantity,omitempty"`
 }
 
 // TaskFilter contains optional query filters.

--- a/backend/internal/middleware/security_headers.go
+++ b/backend/internal/middleware/security_headers.go
@@ -1,0 +1,14 @@
+package middleware
+
+import "net/http"
+
+// SecurityHeaders sets standard browser security headers on every response.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/repository/task_repo.go
+++ b/backend/internal/repository/task_repo.go
@@ -241,6 +241,10 @@ func (r *taskRepo) Update(id uuid.UUID, input domain.UpdateTaskInput) (*domain.T
 		setClauses = append(setClauses, fmt.Sprintf("assignee_id = $%d", i))
 		args = append(args, *input.AssigneeID)
 		i++
+	} else if input.ClearAssigneeID {
+		setClauses = append(setClauses, fmt.Sprintf("assignee_id = $%d", i))
+		args = append(args, nil)
+		i++
 	}
 	if input.Status != nil {
 		// Status is the source of truth; keep done/done_at in sync.

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -69,6 +69,7 @@ func New(cfg *config.Config, db *pgxpool.Pool, buildTime string) *Server {
 	// Global middleware
 	r.Use(chimiddleware.Recoverer)
 	r.Use(chimiddleware.RequestID)
+	r.Use(middleware.SecurityHeaders)
 	r.Use(middleware.Logger)
 	rawOrigins := strings.Split(cfg.CORSOrigins, ",")
 	allowedOrigins := make([]string, 0, len(rawOrigins))

--- a/frontend/src/components/tasks/TaskDrawer.tsx
+++ b/frontend/src/components/tasks/TaskDrawer.tsx
@@ -223,6 +223,12 @@ export function TaskDrawer({ task, members, onClose, onUpdated, onDeleted }: Pro
                 {m.name}
               </PillBtn>
             ))}
+            {current.assignee_id && (
+              <button
+                onClick={() => { setCurrent({ ...current, assignee_id: '' }); patch({ clear_assignee_id: true }) }}
+                style={{ padding: '5px 10px', borderRadius: 99, border: '1px solid #ede8e1', background: 'white', color: '#a8a29e', fontSize: 12, cursor: 'pointer', transition: 'all 0.12s' }}
+              >Unassign</button>
+            )}
           </div>
 
           <div style={{ height: 1, background: '#faf7f2', marginBottom: 14 }} />

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -6,7 +6,7 @@ import { groceriesApi } from '../api/groceries'
 
 function applyTaskPatch(task: Task, payload: UpdateTaskPayload, members: Member[]): Task {
   const now = new Date().toISOString()
-  const nextAssigneeID = payload.assignee_id !== undefined ? payload.assignee_id : task.assignee_id
+  const nextAssigneeID = payload.clear_assignee_id ? undefined : payload.assignee_id !== undefined ? payload.assignee_id : task.assignee_id
   const nextDueAt = payload.clear_due_at ? undefined : payload.due_at !== undefined ? payload.due_at : task.due_at
   const nextQuantity = payload.quantity !== undefined ? payload.quantity : task.quantity
 
@@ -26,8 +26,8 @@ function applyTaskPatch(task: Task, payload: UpdateTaskPayload, members: Member[
     notes: payload.notes ?? task.notes,
     category: payload.category ?? task.category,
     priority: payload.priority ?? task.priority,
-    assignee_id: nextAssigneeID,
-    assignee: members.find((member) => member.id === nextAssigneeID) ?? task.assignee,
+    assignee_id: nextAssigneeID ?? '',
+    assignee: nextAssigneeID ? (members.find((member) => member.id === nextAssigneeID) ?? task.assignee) : undefined,
     due_at: nextDueAt,
     quantity: nextQuantity,
     status: nextStatus,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -37,7 +37,7 @@ export interface CreateTaskPayload {
 }
 export interface UpdateTaskPayload {
   title?: string; notes?: string; category?: Category; priority?: Priority
-  assignee_id?: string; status?: TaskStatus; done?: boolean; due_at?: string; clear_due_at?: boolean; quantity?: string
+  assignee_id?: string; clear_assignee_id?: boolean; status?: TaskStatus; done?: boolean; due_at?: string; clear_due_at?: boolean; quantity?: string
 }
 
 export const CATEGORIES: Record<Category, { label: string; color: string }> = {


### PR DESCRIPTION
## Summary

- Adds browser security headers to every API response via a new global middleware
- Adds an Unassign button to TaskDrawer — previously impossible to clear an assignee once set

## Type of change

- [x] Bug fix

## Issues closed

Closes #190, Closes #134

## Changes

**Backend**
- `middleware/security_headers.go`: new middleware sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`
- `server.go`: registers `SecurityHeaders` globally before all routes
- `domain/task.go`: adds `ClearAssigneeID bool` to `UpdateTaskInput` (mirrors `ClearDueAt` pattern)
- `task_repo.go`: sets `assignee_id = NULL` when `ClearAssigneeID` is true

**Frontend**
- `types/index.ts`: adds `clear_assignee_id?: boolean` to `UpdateTaskPayload`
- `store/index.ts`: `applyTaskPatch` clears assignee when `clear_assignee_id` is set
- `TaskDrawer.tsx`: renders Unassign button next to member pills when task has an assignee

## Test plan

- [x] `go build ./...` passes
- [x] `npm run build` passes
- [ ] `curl -I https://homejira-staging.up.railway.app/health` — verify security headers present
- [ ] Open a task with an assignee → Unassign button visible → click clears assignee immediately (optimistic) and persists after reload
- [ ] Open a task with no assignee → Unassign button not shown

## Size

XS

🤖 Generated with [Claude Code](https://claude.com/claude-code)