### PR TITLE
fix: use Railway GraphQL API to trigger staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -11,8 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Trigger Railway staging deploy
-        run: curl -sf -X POST "${{ secrets.RAILWAY_DEPLOY_WEBHOOK }}"
+      - name: Trigger Railway staging redeploy
+        run: |
+          curl -sf -X POST https://backboard.railway.app/graphql/v2 \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
+            --data-raw '{"query":"mutation { serviceInstanceRedeploy(environmentId: \"69042cbe-48cf-4e8f-8dda-8d85d489b16f\", serviceId: \"35dfbdfb-5364-427f-92a8-edc7cf1850af\") }"}'
 
       - name: Wait for staging to serve new commit
         run: |


### PR DESCRIPTION
## Summary

- Replaces `RAILWAY_DEPLOY_WEBHOOK` (static URL) with a direct call to Railway's GraphQL `serviceInstanceRedeploy` mutation
- `RAILWAY_TOKEN` secret is now set in GitHub Actions repo secrets

## Type of change

- [x] Infrastructure / DevOps

## What changed

The existing `deploy-staging.yml` POSTed to a static webhook URL (`RAILWAY_DEPLOY_WEBHOOK`). Railway doesn't expose deploy hook URLs via their API — they're dashboard-only. Instead, we now call the Railway GraphQL API directly:

```bash
curl -X POST https://backboard.railway.app/graphql/v2 \
  -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
  --data-raw '{"query":"mutation { serviceInstanceRedeploy(environmentId: \"...\", serviceId: \"...\") }"}'
```

Confirmed working — tested mutation against staging before wiring up.

## Test plan

- [x] Mutation tested manually against Railway staging — returned `{"data":{"serviceInstanceRedeploy":true}}`
- [x] `RAILWAY_TOKEN` secret set in GitHub repo Actions secrets
- [ ] Merge and verify the deploy job runs green on next push to main

## Size

XS

🤖 Generated with [Claude Code](https://claude.com/claude-code)