### PR TITLE
Fix: Android CORS compatibility

### DIFF
--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -80,7 +80,7 @@ func New(cfg *config.Config, db *pgxpool.Pool, buildTime string) *Server {
 		}
 	}
 	// Always allow mobile capacitor origins
-	allowedOrigins = append(allowedOrigins, "capacitor://localhost", "http://localhost")
+	allowedOrigins = append(allowedOrigins, "capacitor://localhost", "http://localhost", "https://localhost")
 
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   allowedOrigins,


### PR DESCRIPTION
Allows https://localhost origin required by some Android Capacitor configurations.