### PR TITLE
Fix: Grocery section UX bugs and code quality improvements

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2966,9 +2966,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4924,9 +4924,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6121,9 +6121,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6685,9 +6685,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/components/tasks/AddGrocerySheet.tsx
+++ b/frontend/src/components/tasks/AddGrocerySheet.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { type Member, type CreateGroceryPayload } from '../../types'
 import { useStore } from '../../store'
 import { useBreakpoint } from '../../hooks/useBreakpoint'
+import { COLOR_PRIMARY } from '../../constants/layout'
 
 interface Props {
   members: Member[]
@@ -15,7 +16,7 @@ export function AddGrocerySheet({ members, onClose, onAdded }: Props) {
 
   const [form, setForm] = useState<CreateGroceryPayload>({
     title: '', quantity: '', notes: '',
-    assignee_id: members[0]?.id ?? '',
+    assignee_id: '',
   })
   const [saving, setSaving] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -48,8 +49,6 @@ export function AddGrocerySheet({ members, onClose, onAdded }: Props) {
       setSaving(false)
     }
   }
-
-  const ACCENT = '#6366f1'
 
   return (
     <div
@@ -87,7 +86,7 @@ export function AddGrocerySheet({ members, onClose, onAdded }: Props) {
           placeholder="e.g. Milk, bread, eggs"
           onKeyDown={(e) => e.key === 'Enter' && submit()}
           style={{
-            width: '100%', fontSize: 15, border: `1px solid ${form.title ? ACCENT + '60' : '#ede8e1'}`,
+            width: '100%', fontSize: 15, border: `1px solid ${form.title ? COLOR_PRIMARY + '60' : '#ede8e1'}`,
             borderRadius: 8, padding: '11px 12px', outline: 'none', marginBottom: 10,
             color: '#1c1917', background: '#fafafa', boxSizing: 'border-box',
           }}
@@ -122,6 +121,15 @@ export function AddGrocerySheet({ members, onClose, onAdded }: Props) {
           Assign to
         </p>
         <div style={{ display: 'flex', gap: 6, marginBottom: 20, flexWrap: 'wrap' }}>
+          <button
+            onClick={() => set('assignee_id', '')}
+            style={{
+              padding: '5px 12px', borderRadius: 99, border: '1px solid', fontWeight: 600, fontSize: 12, cursor: 'pointer',
+              borderColor: form.assignee_id === '' ? '#a8a29e' : '#ede8e1',
+              background: form.assignee_id === '' ? '#f5f5f4' : 'white',
+              color: form.assignee_id === '' ? '#78716c' : '#a8a29e',
+            }}
+          >Unassigned</button>
           {members.map((m) => (
             <button key={m.id} onClick={() => set('assignee_id', m.id)} style={{
               padding: '5px 12px', borderRadius: 99, border: '1px solid', fontWeight: 600, fontSize: 12, cursor: 'pointer',
@@ -144,7 +152,7 @@ export function AddGrocerySheet({ members, onClose, onAdded }: Props) {
           style={{
             width: '100%', border: 'none', borderRadius: 10, padding: 14,
             fontSize: 15, fontWeight: 700, cursor: saving || !form.title.trim() ? 'not-allowed' : 'pointer',
-            background: saving || !form.title.trim() ? '#ede8e1' : ACCENT,
+            background: saving || !form.title.trim() ? '#ede8e1' : COLOR_PRIMARY,
             color: saving || !form.title.trim() ? '#a8a29e' : 'white',
             transition: 'background 0.15s',
           }}

--- a/frontend/src/constants/layout.ts
+++ b/frontend/src/constants/layout.ts
@@ -1,3 +1,5 @@
 export const TOP_BAR_HEIGHT = 57
 export const SIDE_NAV_WIDTH = 220
 export const DESKTOP_BREAKPOINT = 900
+
+export const COLOR_PRIMARY = '#6366f1'

--- a/frontend/src/pages/GroceryPage.tsx
+++ b/frontend/src/pages/GroceryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useStore } from '../store'
 import { useAuthStore } from '../store/authStore'
@@ -6,8 +6,10 @@ import { Spinner } from '../components/ui/Spinner'
 import { AddGrocerySheet } from '../components/tasks/AddGrocerySheet'
 import { useBreakpoint } from '../hooks/useBreakpoint'
 import type { Grocery, Member, UpdateGroceryPayload } from '../types'
+import { COLOR_PRIMARY } from '../constants/layout'
+import { groupByDay } from '../utils'
 
-const ACCENT = '#6366f1'
+type View = 'list' | 'history'
 
 export function GroceryPage() {
   const { groceries, fetchGroceries, toggleGrocery, deleteGrocery, updateGrocery, sseVersion, members } = useStore()
@@ -16,11 +18,12 @@ export function GroceryPage() {
 
   const [loading, setLoading] = useState(groceries.length === 0)
   const [showDone, setShowDone] = useState(true)
-  const [historyMode, setHistoryMode] = useState(false)
-  const todayKey = (() => { const d = new Date(); d.setHours(0,0,0,0); return d.toISOString() })()
+  const [view, setView] = useState<View>('list')
+  const todayKey = useMemo(() => { const d = new Date(); d.setHours(0,0,0,0); return d.toISOString() }, [])
   const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set([todayKey]))
   const [showAdd, setShowAdd] = useState(false)
   const [selectedItem, setSelectedItem] = useState<Grocery | null>(null)
+  const [checkingAll, setCheckingAll] = useState(false)
 
   // Initial load — shows spinner while data is absent
   const load = useCallback(async () => {
@@ -40,27 +43,34 @@ export function GroceryPage() {
     if (!selectedItem) return
     const updated = groceries.find(g => g.id === selectedItem.id)
     if (!updated) setSelectedItem(null) // deleted elsewhere
-  }, [groceries, selectedItem])
+    else setSelectedItem(updated) // reflect any remote updates
+  }, [groceries]) // intentionally excludes selectedItem to avoid loop
 
-  const active = groceries.filter(g => !g.done)
-  const done = groceries.filter(g => g.done).sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+  const active = useMemo(() => groceries.filter(g => !g.done), [groceries])
+  const done = useMemo(() => groceries.filter(g => g.done).sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()), [groceries])
 
   const handleCheckAll = async () => {
-    await Promise.allSettled(active.map(g => toggleGrocery(g.id, true)))
-    setShowDone(true)
+    setCheckingAll(true)
+    try {
+      await Promise.allSettled(active.map(g => toggleGrocery(g.id, true)))
+      setShowDone(true)
+    } finally {
+      setCheckingAll(false)
+    }
   }
 
   if (!member?.household_id) return <Navigate to="/household" replace />
 
   if (loading) return <Spinner />
 
-  if (historyMode) {
+  if (view === 'history') {
     return (
       <div style={{ paddingBottom: 80 }}>
         <div style={{ background: 'white', padding: '12px 16px', borderBottom: '1px solid #ede8e1', position: 'sticky', top: 'calc(57px + env(safe-area-inset-top, 0px))', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <button
-            onClick={() => setHistoryMode(false)}
-            style={{ background: 'none', border: 'none', color: ACCENT, fontSize: 13, fontWeight: 700, cursor: 'pointer', padding: 0, display: 'flex', alignItems: 'center', gap: 4 }}
+            onClick={() => setView('list')}
+            aria-label="Back to list"
+            style={{ background: 'none', border: 'none', color: COLOR_PRIMARY, fontSize: 13, fontWeight: 700, cursor: 'pointer', padding: 0, display: 'flex', alignItems: 'center', gap: 4 }}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="15,18 9,12 15,6" />
@@ -88,6 +98,7 @@ export function GroceryPage() {
                 <div key={key} style={{ marginBottom: 8 }}>
                   <button
                     onClick={toggle}
+                    aria-label={`${open ? 'Collapse' : 'Expand'} ${label}`}
                     style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'none', border: 'none', cursor: 'pointer', padding: '8px 4px', marginBottom: open ? 4 : 0 }}
                   >
                     <span style={{ fontSize: 11, fontWeight: 700, color: '#a8a29e', letterSpacing: 0.6, textTransform: 'uppercase' }}>{label}</span>
@@ -98,8 +109,8 @@ export function GroceryPage() {
                       </svg>
                     </div>
                   </button>
-                  {open && items.map(item => (
-                    <HistoryRow key={item.id} item={item} onDelete={deleteGrocery} onSelect={setSelectedItem} />
+                  {open && (items as Grocery[]).map(item => (
+                    <HistoryRow key={item.id} item={item} onSelect={setSelectedItem} />
                   ))}
                 </div>
               )
@@ -124,7 +135,8 @@ export function GroceryPage() {
     <div style={{ background: 'white', padding: '10px 16px', borderBottom: '1px solid #ede8e1', position: 'sticky', top: 'calc(57px + env(safe-area-inset-top, 0px))', zIndex: 49, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
       <h2 style={{ fontSize: 13, fontWeight: 600, color: '#78716c', margin: 0, letterSpacing: 0.2 }}>Grocery</h2>
       <button
-        onClick={() => setHistoryMode(true)}
+        onClick={() => setView('history')}
+        aria-label="View history"
         style={{ background: 'none', border: 'none', color: '#78716c', fontSize: 12, fontWeight: 600, cursor: 'pointer', padding: '4px 8px', borderRadius: 6, display: 'flex', alignItems: 'center', gap: 4 }}
       >
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -138,7 +150,7 @@ export function GroceryPage() {
   const emptyState = (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '64px 24px', textAlign: 'center' }}>
       <div style={{ width: 60, height: 60, borderRadius: 18, background: '#eef2ff', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>
-        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke={ACCENT} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke={COLOR_PRIMARY} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
           <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
           <line x1="3" y1="6" x2="21" y2="6" /><path d="M16 10a4 4 0 01-8 0" />
         </svg>
@@ -146,6 +158,18 @@ export function GroceryPage() {
       <p style={{ fontSize: 16, fontWeight: 700, color: '#1c1917', margin: '0 0 6px' }}>List is empty</p>
       <p style={{ fontSize: 13, color: '#a8a29e', margin: 0, lineHeight: 1.6 }}>Tap the + button to add items to your list.</p>
     </div>
+  )
+
+  const checkAllButton = (
+    <button
+      onClick={handleCheckAll}
+      disabled={checkingAll}
+      aria-label="Mark all items as done"
+      style={{ background: 'none', border: 'none', color: checkingAll ? '#a8a29e' : '#78716c', fontSize: 11, fontWeight: 600, cursor: checkingAll ? 'default' : 'pointer', padding: '4px 8px', borderRadius: 6, display: 'flex', alignItems: 'center', gap: 4 }}
+    >
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20,6 9,17 4,12" /></svg>
+      {checkingAll ? 'Checking…' : 'Check all'}
+    </button>
   )
 
   return (
@@ -158,10 +182,7 @@ export function GroceryPage() {
           <div style={{ flex: 1, padding: '0 16px', borderRight: '1px solid #ede8e1', minWidth: 0 }}>
             {active.length > 1 && (
               <div style={{ padding: '10px 0', display: 'flex', justifyContent: 'flex-end' }}>
-                <button onClick={handleCheckAll} style={{ background: 'none', border: 'none', color: '#78716c', fontSize: 11, fontWeight: 600, cursor: 'pointer', padding: '4px 8px', borderRadius: 6, display: 'flex', alignItems: 'center', gap: 4 }}>
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20,6 9,17 4,12" /></svg>
-                  Check all
-                </button>
+                {checkAllButton}
               </div>
             )}
             {active.length === 0 && done.length === 0 && emptyState}
@@ -202,10 +223,7 @@ export function GroceryPage() {
         <div style={{ padding: '0 12px 0' }}>
           {active.length > 1 && (
             <div style={{ padding: '8px 0', display: 'flex', justifyContent: 'flex-end' }}>
-              <button onClick={handleCheckAll} style={{ background: 'none', border: 'none', color: '#78716c', fontSize: 11, fontWeight: 600, cursor: 'pointer', padding: '4px 8px', borderRadius: 6, display: 'flex', alignItems: 'center', gap: 4 }}>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20,6 9,17 4,12" /></svg>
-                Check all
-              </button>
+              {checkAllButton}
             </div>
           )}
 
@@ -246,11 +264,12 @@ export function GroceryPage() {
 
       <button
         onClick={() => setShowAdd(true)}
+        aria-label="Add grocery item"
         style={{
           position: 'fixed', bottom: isDesktop ? 24 : 72, right: 20, width: 56, height: 56,
-          borderRadius: 16, background: ACCENT, color: 'white', border: 'none',
+          borderRadius: 16, background: COLOR_PRIMARY, color: 'white', border: 'none',
           fontSize: 28, display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow: `0 8px 24px ${ACCENT}40`, zIndex: 40, cursor: 'pointer', transition: 'transform .1s',
+          boxShadow: `0 8px 24px ${COLOR_PRIMARY}40`, zIndex: 40, cursor: 'pointer', transition: 'transform .1s',
         }}
         onMouseDown={e => (e.currentTarget.style.transform = 'scale(.94)')}
         onMouseUp={e => (e.currentTarget.style.transform = 'scale(1)')}
@@ -273,33 +292,6 @@ export function GroceryPage() {
   )
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function groupByDay(items: Grocery[]): { key: string; label: string; items: Grocery[] }[] {
-  const now = new Date()
-  const today = new Date(now); today.setHours(0, 0, 0, 0)
-  const yesterday = new Date(today); yesterday.setDate(yesterday.getDate() - 1)
-
-  const map = new Map<string, Grocery[]>()
-  for (const item of items) {
-    const d = new Date(item.updated_at); d.setHours(0, 0, 0, 0)
-    const key = d.toISOString()
-    if (!map.has(key)) map.set(key, [])
-    map.get(key)!.push(item)
-  }
-
-  return Array.from(map.entries())
-    .sort(([a], [b]) => b.localeCompare(a))
-    .map(([key, items]) => {
-      const d = new Date(key)
-      let label: string
-      if (d.getTime() === today.getTime()) label = 'Today'
-      else if (d.getTime() === yesterday.getTime()) label = 'Yesterday'
-      else label = d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', ...(d.getFullYear() !== now.getFullYear() ? { year: 'numeric' } : {}) })
-      return { key, label, items }
-    })
-}
-
 // ── GroceryRow ────────────────────────────────────────────────────────────────
 
 interface RowProps {
@@ -320,9 +312,9 @@ function GroceryRow({ item, done = false, onToggle, onSelect }: RowProps) {
         opacity: done ? 0.55 : 1, transition: 'opacity 0.15s', cursor: 'pointer',
       }}
     >
-      {/* Circular tick button */}
       <button
         onClick={e => { e.stopPropagation(); onToggle(!done) }}
+        aria-label={done ? 'Mark as not done' : 'Mark as done'}
         style={{
           width: 26, height: 26, borderRadius: '50%', flexShrink: 0,
           border: `1.5px solid ${done ? '#22c55e' : '#d4d4d8'}`,
@@ -342,7 +334,6 @@ function GroceryRow({ item, done = false, onToggle, onSelect }: RowProps) {
         )}
       </button>
 
-      {/* Content */}
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontSize: 14, fontWeight: 500, textDecoration: done ? 'line-through' : 'none', color: done ? '#a8a29e' : '#1c1917', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {item.title}
@@ -354,11 +345,10 @@ function GroceryRow({ item, done = false, onToggle, onSelect }: RowProps) {
         )}
       </div>
 
-      {/* Assignee avatar */}
       {item.assignee && (
         <span style={{
           width: 22, height: 22, borderRadius: '50%', flexShrink: 0,
-          background: item.assignee.color ?? ACCENT,
+          background: item.assignee.color ?? COLOR_PRIMARY,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           fontSize: 10, fontWeight: 700, color: 'white',
         }}>
@@ -366,8 +356,7 @@ function GroceryRow({ item, done = false, onToggle, onSelect }: RowProps) {
         </span>
       )}
 
-      {/* Chevron hint */}
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#d4d4d8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#d4d4d8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
         <polyline points="9,18 15,12 9,6" />
       </svg>
     </div>
@@ -411,6 +400,9 @@ function GroceryDetailSheet({ item, members, onClose, onToggle, onUpdate, onDele
 
   useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current) }, [])
 
+  // Sync assignee from remote updates (SSE) — immediate field, no debounce in flight
+  useEffect(() => { setAssigneeId(item.assignee?.id ?? '') }, [item.assignee?.id])
+
   const handleTitle = (v: string) => { setTitle(v); scheduleUpdate({ title: v }) }
   const handleQuantity = (v: string) => { setQuantity(v); scheduleUpdate({ quantity: v || undefined }) }
   const handleNotes = (v: string) => { setNotes(v); scheduleUpdate({ notes: v }) }
@@ -440,9 +432,9 @@ function GroceryDetailSheet({ item, members, onClose, onToggle, onUpdate, onDele
 
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 20 }}>
-          {/* Done toggle */}
           <button
             onClick={() => onToggle(!item.done)}
+            aria-label={item.done ? 'Mark as not done' : 'Mark as done'}
             style={{
               width: 30, height: 30, borderRadius: '50%', flexShrink: 0,
               border: `1.5px solid ${item.done ? '#22c55e' : '#d4d4d8'}`,
@@ -462,7 +454,7 @@ function GroceryDetailSheet({ item, members, onClose, onToggle, onUpdate, onDele
           </span>
           <div style={{ flex: 1 }} />
           {syncing && <span style={{ fontSize: 11, color: '#a8a29e' }}>Saving…</span>}
-          <button onClick={onClose} style={{ background: '#faf7f2', border: 'none', borderRadius: 8, padding: '5px 12px', fontSize: 13, color: '#78716c', cursor: 'pointer' }}>Done</button>
+          <button onClick={onClose} style={{ background: '#faf7f2', border: 'none', borderRadius: 8, padding: '5px 12px', fontSize: 13, color: '#78716c', cursor: 'pointer' }}>Close</button>
         </div>
 
         {/* Title */}
@@ -555,7 +547,7 @@ function GroceryDetailSheet({ item, members, onClose, onToggle, onUpdate, onDele
 
 // ── HistoryRow ────────────────────────────────────────────────────────────────
 
-function HistoryRow({ item, onDelete, onSelect }: { item: Grocery; onDelete: (id: string) => void; onSelect: (item: Grocery) => void }) {
+function HistoryRow({ item, onSelect }: { item: Grocery; onSelect: (item: Grocery) => void }) {
   return (
     <div
       onClick={() => onSelect(item)}
@@ -578,7 +570,7 @@ function HistoryRow({ item, onDelete, onSelect }: { item: Grocery; onDelete: (id
         <div style={{ fontSize: 14, color: '#a8a29e', textDecoration: 'line-through', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.title}</div>
         {item.quantity && <div style={{ fontSize: 11, color: '#a8a29e', marginTop: 1 }}>{item.quantity}</div>}
       </div>
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#d4d4d8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#d4d4d8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
         <polyline points="9,18 15,12 9,6" />
       </svg>
     </div>

--- a/frontend/src/pages/GroceryPage.tsx
+++ b/frontend/src/pages/GroceryPage.tsx
@@ -109,7 +109,7 @@ export function GroceryPage() {
                       </svg>
                     </div>
                   </button>
-                  {open && (items as Grocery[]).map(item => (
+                  {open && items.map(item => (
                     <HistoryRow key={item.id} item={item} onSelect={setSelectedItem} />
                   ))}
                 </div>

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -200,8 +200,25 @@ export const useStore = create<AppStore>()(
       },
 
       updateGrocery: async (id, payload) => {
-        const updated = await groceriesApi.update(id, payload)
-        set((s) => ({ groceries: s.groceries.map((g) => g.id === id ? updated : g) }))
+        const previous = get().groceries.find(g => g.id === id)
+        if (!previous) return
+        set(s => ({
+          groceries: s.groceries.map(g => g.id === id ? { ...g, ...payload, updated_at: new Date().toISOString() } : g),
+          groceryPending: s.groceryPending + 1,
+        }))
+        try {
+          const updated = await groceriesApi.update(id, payload)
+          set(s => ({
+            groceries: s.groceries.map(g => g.id === id ? updated : g),
+            groceryPending: Math.max(0, s.groceryPending - 1),
+          }))
+        } catch {
+          set(s => ({
+            groceries: s.groceries.map(g => g.id === id ? previous : g),
+            groceryPending: Math.max(0, s.groceryPending - 1),
+          }))
+          get().showToast('Could not update item — please try again.')
+        }
       },
 
       deleteGrocery: async (id) => {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -25,3 +25,28 @@ export function isDueSoon(dueAt: string | undefined, done: boolean): boolean {
   const ms = new Date(dueAt).getTime() - Date.now()
   return ms > 0 && ms <= 86_400_000
 }
+
+export function groupByDay(items: { updated_at: string; [key: string]: unknown }[]): { key: string; label: string; items: typeof items }[] {
+  const now = new Date()
+  const today = new Date(now); today.setHours(0, 0, 0, 0)
+  const yesterday = new Date(today); yesterday.setDate(yesterday.getDate() - 1)
+
+  const map = new Map<string, typeof items>()
+  for (const item of items) {
+    const d = new Date(item.updated_at); d.setHours(0, 0, 0, 0)
+    const key = d.toISOString()
+    if (!map.has(key)) map.set(key, [])
+    map.get(key)!.push(item)
+  }
+
+  return Array.from(map.entries())
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([key, items]) => {
+      const d = new Date(key)
+      let label: string
+      if (d.getTime() === today.getTime()) label = 'Today'
+      else if (d.getTime() === yesterday.getTime()) label = 'Yesterday'
+      else label = d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', ...(d.getFullYear() !== now.getFullYear() ? { year: 'numeric' } : {}) })
+      return { key, label, items }
+    })
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -26,7 +26,7 @@ export function isDueSoon(dueAt: string | undefined, done: boolean): boolean {
   return ms > 0 && ms <= 86_400_000
 }
 
-export function groupByDay(items: { updated_at: string; [key: string]: unknown }[]): { key: string; label: string; items: typeof items }[] {
+export function groupByDay<T extends { updated_at: string }>(items: T[]): { key: string; label: string; items: T[] }[] {
   const now = new Date()
   const today = new Date(now); today.setHours(0, 0, 0, 0)
   const yesterday = new Date(today); yesterday.setDate(yesterday.getDate() - 1)


### PR DESCRIPTION
## Summary

- **Bug**: `AddGrocerySheet` was silently pre-assigning `members[0]` as default assignee — fixed to `''` (unassigned), with an Unassigned pill added
- **Bug**: `selectedItem` detail sheet didn't sync with SSE updates while open — now updates in real-time; `assigneeId` local state also syncs from item prop changes
- **UX**: Renamed confusing "Done" close button → "Close" (sat directly above "Mark as done" toggle)
- **Correctness**: `updateGrocery` now optimistic with immediate UI update, rollback on failure, and `groceryPending` guard against SSE races
- **UX**: "Check all" shows "Checking…" and is disabled during the N-request batch
- **a11y**: `aria-label` added to all icon-only buttons; decorative chevrons marked `aria-hidden`
- **DX**: `COLOR_PRIMARY` extracted to `constants/layout.ts` (removes duplicated `ACCENT` literals)
- **DX**: `groupByDay` moved to `utils/index.ts` (was buried at line 278 of GroceryPage)
- **DX**: `historyMode: boolean` replaced with `view: 'list' | 'history'` typed enum
- **DX**: `checkAllButton` deduplicated (was copy-pasted for mobile/desktop)
- **DX**: Dead `onDelete` prop removed from `HistoryRow`
- **Perf**: `active`, `done`, `todayKey` memoized

## Test plan

- [ ] Open grocery page — no items pre-assigned when adding a new item
- [ ] Add item with Unassigned selected — confirm no assignee on saved item
- [ ] Open an item detail sheet, have another household member update it — confirm assignee chip updates without closing sheet
- [ ] Edit title/quantity in detail sheet — confirm list row updates optimistically, "Saving…" indicator appears
- [ ] Edit title/quantity in detail sheet — simulate network failure — confirm rollback + toast
- [ ] Tap "Check all" with 2+ items — confirm button shows "Checking…" and is disabled during flight
- [ ] Close button on detail sheet no longer reads "Done"
- [ ] Screen reader / accessibility audit: all buttons have labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)